### PR TITLE
Fix parsing of numeric sensor fields

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -3,20 +3,26 @@ export function trimOldEntries(entries, now = Date.now()) {
     return entries.filter(e => now - e.timestamp < DAY);
 }
 
+function toNumber(value, fallback = 0) {
+    if (value === undefined || value === null) return fallback;
+    const n = Number(value);
+    return Number.isFinite(n) ? n : fallback;
+}
+
 export function normalizeSensorData(data = {}) {
     return {
-        F1: data.ch415 ?? data.F1 ?? 0,
-        F2: data.ch445 ?? data.F2 ?? 0,
-        F3: data.ch480 ?? data.F3 ?? 0,
-        F4: data.ch515 ?? data.F4 ?? 0,
-        F5: data.ch555 ?? data.F5 ?? 0,
-        F6: data.ch590 ?? data.F6 ?? 0,
-        F7: data.ch630 ?? data.F7 ?? 0,
-        F8: data.ch680 ?? data.F8 ?? 0,
-        clear: data.clear ?? 0,
-        nir: data.nir ?? 0,
-        temperature: data.temperature ?? 0,
-        lux: data.lux ?? 0,
+        F1: toNumber(data.ch415 ?? data.F1, 0),
+        F2: toNumber(data.ch445 ?? data.F2, 0),
+        F3: toNumber(data.ch480 ?? data.F3, 0),
+        F4: toNumber(data.ch515 ?? data.F4, 0),
+        F5: toNumber(data.ch555 ?? data.F5, 0),
+        F6: toNumber(data.ch590 ?? data.F6, 0),
+        F7: toNumber(data.ch630 ?? data.F7, 0),
+        F8: toNumber(data.ch680 ?? data.F8, 0),
+        clear: toNumber(data.clear, 0),
+        nir: toNumber(data.nir, 0),
+        temperature: toNumber(data.temperature, 0),
+        lux: toNumber(data.lux, 0),
         health: {
             veml7700: data.health?.veml7700 ?? true,
             as7341: data.health?.as7341 ?? true,

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -31,6 +31,14 @@ test('includes health statuses', () => {
     expect(result.health.as7341).toBe(true);
 });
 
+test('parses numeric strings into numbers', () => {
+    const raw = { ch415: '10', temperature: '21.5', lux: '30' };
+    const result = normalizeSensorData(raw);
+    expect(result.F1).toBe(10);
+    expect(result.temperature).toBe(21.5);
+    expect(result.lux).toBe(30);
+});
+
 test('filterNoise discards out of range values', () => {
     const clean = {
         F1: 100, F2: 100, F3: 100, F4: 100,


### PR DESCRIPTION
## Summary
- robustify `normalizeSensorData` to convert numeric strings
- add test for numeric string parsing

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68767f19cf6083288b43a15d5c76691a