### PR TITLE
Refactor dashboard header and add sensor cards

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,12 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import styles from './Header.module.css';
 
-function StatusDot({ ok }) {
-    const className = `${styles.statusDot} ${ok ? styles.ok : styles.bad}`;
-    return <span className={className} />;
-}
-
-function Header({ topic, temperature, humidity = 0, lux, health = {} }) {
+function Header({ topic }) {
     const [now, setNow] = useState(() => new Date());
 
     useEffect(() => {
@@ -16,20 +11,8 @@ function Header({ topic, temperature, humidity = 0, lux, health = {} }) {
 
     return (
         <header className={styles.header}>
-            <h1 className={styles.title}>🌿 AzadFarm Dashboard</h1>
-            <div className={styles.info}>
-                <span>Time: {now.toLocaleTimeString()}</span>
-                <span>Temp: {temperature.toFixed(1)}°C</span>
-                <span>Humidity: {humidity.toFixed(1)}%</span>
-                <span>Lux: {lux.toFixed(1)}</span>
-                <span>Topic: {topic}</span>
-                {Object.entries(health).map(([name, ok]) => (
-                    <span key={name} className={styles.sensor}>
-                        {name}
-                        <StatusDot ok={ok} />
-                    </span>
-                ))}
-            </div>
+            <h1 className={styles.title}>{topic} Dashboard</h1>
+            <div className={styles.time}>{now.toLocaleTimeString()}</div>
         </header>
     );
 }

--- a/src/components/Header.module.css
+++ b/src/components/Header.module.css
@@ -1,30 +1,15 @@
 .header {
+    background-color: #4e79a7;
+    color: white;
     padding: 10px 20px;
-    border-bottom: 1px solid #ccc;
     margin-bottom: 20px;
+    text-align: center;
 }
+
 .title {
     margin: 0;
 }
-.info {
-    display: flex;
-    gap: 1rem;
-    flex-wrap: wrap;
-}
-.sensor {
-    display: flex;
-    align-items: center;
-}
-.statusDot {
-    display: inline-block;
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    margin-left: 4px;
-}
-.statusDot.ok {
-    background-color: green;
-}
-.statusDot.bad {
-    background-color: red;
+
+.time {
+    margin-top: 4px;
 }

--- a/src/components/SensorCard.jsx
+++ b/src/components/SensorCard.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import styles from './SensorCard.module.css';
+
+function SensorCard({ name, ok, children }) {
+    const headerClass = `${styles.header} ${ok ? styles.on : styles.off}`;
+    return (
+        <div className={styles.card}>
+            <div className={headerClass}>{name}: {ok ? 'On' : 'Off'}</div>
+            <div className={styles.body}>{children}</div>
+        </div>
+    );
+}
+
+export default SensorCard;

--- a/src/components/SensorCard.module.css
+++ b/src/components/SensorCard.module.css
@@ -1,0 +1,26 @@
+.card {
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    overflow: hidden;
+    width: 200px;
+    margin: 10px;
+}
+
+.header {
+    color: white;
+    text-align: center;
+    padding: 4px 0;
+}
+
+.on {
+    background-color: green;
+}
+
+.off {
+    background-color: red;
+}
+
+.body {
+    padding: 8px;
+}
+

--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -13,6 +13,7 @@ import {
 import DailyTemperatureChart from "./DailyTemperatureChart";
 import MultiBandChart from "./MultiBandChart";
 import Header from "./Header";
+import SensorCard from "./SensorCard";
 import { trimOldEntries, normalizeSensorData, filterNoise } from "../utils";
 import styles from './SensorDashboard.module.css';
 
@@ -138,15 +139,25 @@ function SensorDashboard() {
     ];
 
 
+    const sensorFieldMap = {
+        veml7700: ['lux'],
+        sht3x: ['temperature', 'humidity'],
+        as7341: ['F1','F2','F3','F4','F5','F6','F7','F8','clear','nir']
+    };
+
     return (
         <div className={styles.dashboard}>
-            <Header
-                topic={topic}
-                temperature={sensorData.temperature}
-                humidity={sensorData.humidity}
-                lux={sensorData.lux}
-                health={sensorData.health}
-            />
+            <Header topic={topic} />
+
+            <div className={styles.sensorGrid}>
+                {Object.entries(sensorData.health).map(([name, ok]) => (
+                    <SensorCard key={name} name={name} ok={ok}>
+                        {sensorFieldMap[name]?.map(field => (
+                            <div key={field}>{field}: {Number(sensorData[field]).toFixed ? Number(sensorData[field]).toFixed(1) : sensorData[field]}</div>
+                        ))}
+                    </SensorCard>
+                ))}
+            </div>
 
             <ResponsiveContainer width="100%" height={400}>
                 <BarChart

--- a/src/components/SensorDashboard.module.css
+++ b/src/components/SensorDashboard.module.css
@@ -1,6 +1,10 @@
 .dashboard {
     padding: 20px;
 }
+.sensorGrid {
+    display: flex;
+    flex-wrap: wrap;
+}
 .sectionTitle {
     margin-top: 40px;
 }

--- a/tests/Header.test.jsx
+++ b/tests/Header.test.jsx
@@ -2,9 +2,7 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import Header from '../src/components/Header';
 
-test('shows sensor status labels', () => {
-    const health = { veml7700: true, as7341: false };
-    render(<Header topic="t" temperature={20} humidity={40} lux={50} health={health} />);
-    expect(screen.getByText('veml7700')).toBeInTheDocument();
-    expect(screen.getByText('as7341')).toBeInTheDocument();
+test('renders topic title', () => {
+    render(<Header topic="my/topic" />);
+    expect(screen.getByText('my/topic Dashboard')).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- simplify `Header` component
- style new header with local time
- introduce `SensorCard` component
- show sensor cards for each sensor in dashboard
- update styles and tests accordingly

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876c840cc108328aa6ec97f3655bac7