### PR TITLE
Fix spectrum chart test

### DIFF
--- a/tests/SpectrumBarChart.test.jsx
+++ b/tests/SpectrumBarChart.test.jsx
@@ -1,6 +1,17 @@
+import React from 'react';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { vi } from 'vitest';
 import SpectrumBarChart from '../src/components/SpectrumBarChart';
+
+vi.mock('recharts', async () => {
+    const actual = await vi.importActual('recharts');
+    return {
+        ...actual,
+        ResponsiveContainer: ({ width = 800, height = 400, children }) =>
+            React.cloneElement(children, { width, height }),
+    };
+});
 
 test('renders spectrum bar chart', () => {
     const data = {


### PR DESCRIPTION
## Summary
- mock Recharts `ResponsiveContainer` with fixed dimensions in `SpectrumBarChart.test.jsx`
- ensure the SVG element renders

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876e036eb9883289cfb2bdc1117fd63