### PR TITLE
Fix health indicator color logic

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -8,6 +8,17 @@ function toNumber(value, fallback = 0) {
     return Number.isFinite(n) ? n : fallback;
 }
 
+function toBool(value, fallback = true) {
+    if (value === undefined || value === null) return fallback;
+    if (typeof value === 'boolean') return value;
+    if (typeof value === 'string') {
+        const lower = value.toLowerCase();
+        if (lower === 'true') return true;
+        if (lower === 'false') return false;
+    }
+    return Boolean(value);
+}
+
 export function normalizeSensorData(data = {}) {
     return {
         F1: toNumber(data.ch415 ?? data.F1, 0),
@@ -24,9 +35,9 @@ export function normalizeSensorData(data = {}) {
         humidity: toNumber(data.humidity, 0),
         lux: toNumber(data.lux, 0),
         health: {
-            veml7700: data.health?.veml7700 ?? true,
-            as7341: data.health?.as7341 ?? true,
-            sht3x: data.health?.sht3x ?? true,
+            veml7700: toBool(data.health?.veml7700, true),
+            as7341: toBool(data.health?.as7341, true),
+            sht3x: toBool(data.health?.sht3x, true),
         },
     };
 }

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -43,6 +43,14 @@ test('includes health statuses', () => {
     expect(result.health.sht3x).toBe(false);
 });
 
+test('parses string and numeric health values', () => {
+    const raw = { health: { veml7700: 'false', as7341: 'true', sht3x: 0 } };
+    const result = normalizeSensorData(raw);
+    expect(result.health.veml7700).toBe(false);
+    expect(result.health.as7341).toBe(true);
+    expect(result.health.sht3x).toBe(false);
+});
+
 test('parses numeric strings into numbers', () => {
     const raw = { ch415: '10', temperature: '21.5', humidity: '55', lux: '30' };
     const result = normalizeSensorData(raw);


### PR DESCRIPTION
## Summary
- parse boolean-like values from MQTT health messages
- expand utils tests to cover boolean parsing

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877fd3d26488328926e740b1e00d059