### PR TITLE
Fix temperature chart flicker

### DIFF
--- a/src/components/DailyTemperatureChart.jsx
+++ b/src/components/DailyTemperatureChart.jsx
@@ -9,24 +9,65 @@ import {
     Label
 } from 'recharts';
 
-const DailyTemperatureChart = ({ data, width = 600, height = 300 }) => (
-    <LineChart width={width} height={height} data={data} margin={{ top: 20, right: 30, left: 0, bottom: 50 }}>
-        <CartesianGrid strokeDasharray="3 3" />
-        <XAxis
-            dataKey="time"
-            type="number"
-            domain={[0, 23]}
-            ticks={[...Array(24).keys()]}
-            tickFormatter={h => String(h).padStart(2, '0')}
-            interval={0}
-        />
-        <YAxis>
-            <Label value="°C / %" angle={-90} position="insideLeft" />
-        </YAxis>
-        <Tooltip />
-        <Line type="monotone" dataKey="temperature" stroke="#ff7300" dot={false} />
-        <Line type="monotone" dataKey="humidity" stroke="#8884d8" dot={false} />
-    </LineChart>
-);
+const DailyTemperatureChart = ({
+    data,
+    width = 600,
+    height = 300,
+    xDomain = [Date.now() - 24 * 60 * 60 * 1000, Date.now()],
+}) => {
+    const start = xDomain[0];
+    const end = xDomain[1];
+    const day = 24 * 60 * 60 * 1000;
+    const hour = 60 * 60 * 1000;
+    const interval = end - start <= day * 2 ? hour : day;
+    const ticks = [];
+    for (let t = Math.ceil(start / interval) * interval; t <= end; t += interval) {
+        ticks.push(t);
+    }
+    const tickFormatter = val => {
+        const d = new Date(val);
+        return end - start <= day * 2
+            ? `${String(d.getHours()).padStart(2, '0')}`
+            : `${d.getMonth() + 1}/${d.getDate()}`;
+    };
+
+    return (
+        <LineChart
+            width={width}
+            height={height}
+            data={data}
+            margin={{ top: 20, right: 30, left: 0, bottom: 50 }}
+            isAnimationActive={false}
+        >
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis
+                dataKey="time"
+                type="number"
+                domain={xDomain}
+                ticks={ticks}
+                tickFormatter={tickFormatter}
+                scale="time"
+            />
+            <YAxis>
+                <Label value="°C / %" angle={-90} position="insideLeft" />
+            </YAxis>
+            <Tooltip />
+            <Line
+                type="monotone"
+                dataKey="temperature"
+                stroke="#ff7300"
+                dot={false}
+                isAnimationActive={false}
+            />
+            <Line
+                type="monotone"
+                dataKey="humidity"
+                stroke="#8884d8"
+                dot={false}
+                isAnimationActive={false}
+            />
+        </LineChart>
+    );
+};
 
 export default React.memo(DailyTemperatureChart);

--- a/src/components/MultiBandChart.jsx
+++ b/src/components/MultiBandChart.jsx
@@ -62,7 +62,14 @@ const MultiBandChart = ({
             <Tooltip />
             <Legend />
             {bandKeys.map((key, idx) => (
-                <Line key={key} type="monotone" dataKey={key} stroke={colors[idx % colors.length]} dot={false} />
+                <Line
+                    key={key}
+                    type="monotone"
+                    dataKey={key}
+                    stroke={colors[idx % colors.length]}
+                    dot={false}
+                    isAnimationActive={false}
+                />
             ))}
         </LineChart>
     );

--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -157,7 +157,7 @@ function SensorDashboard() {
             <SpectrumBarChart sensorData={sensorData} />
 
             <h3 className={styles.sectionTitle}>Temperature</h3>
-            <DailyTemperatureChart data={tempRangeData} />
+            <DailyTemperatureChart data={tempRangeData} xDomain={xDomain} />
 
             <h3 className={styles.sectionTitle}>Historical Bands</h3>
             <div className={styles.filterRow}>

--- a/src/components/SpectrumBarChart.jsx
+++ b/src/components/SpectrumBarChart.jsx
@@ -25,14 +25,19 @@ function SpectrumBarChart({ sensorData }) {
 
     return (
         <ResponsiveContainer width="100%" height={400}>
-            <BarChart data={data} margin={{ top: 20, right: 30, left: 0, bottom: 50 }} isAnimationActive={false}>
+            <BarChart
+                data={data}
+                margin={{ top: 20, right: 30, left: 0, bottom: 50 }}
+                isAnimationActive={false}
+                animationDuration={0}
+            >
                 <CartesianGrid strokeDasharray="3 3" />
                 <XAxis dataKey="name" angle={-30} textAnchor="end" interval={0} height={60} />
                 <YAxis>
                     <Label value="PPFD" angle={-90} position="insideLeft" />
                 </YAxis>
                 <Tooltip />
-                <Bar dataKey="value" fill="#82ca9d" isAnimationActive={false} />
+                <Bar dataKey="value" fill="#82ca9d" isAnimationActive={false} animationDuration={0} />
             </BarChart>
         </ResponsiveContainer>
     );


### PR DESCRIPTION
## Summary
- disable animation on Spectrum and Historical charts
- match axis behaviour across charts

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877f9247e5083289cadf7ece914ba19