### PR TITLE
Handle new sensor JSON format

### DIFF
--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -13,7 +13,9 @@ const topic = "azadFarm/sensorData";
 const sensorFieldMap = {
     veml7700: ['lux'],
     sht3x: ['temperature', 'humidity'],
-    as7341: ['F1','F2','F3','F4','F5','F6','F7','F8','clear','nir']
+    as7341: ['F1','F2','F3','F4','F5','F6','F7','F8','clear','nir'],
+    tds: ['tds', 'ec'],
+    ph: []
 };
 
 function SensorDashboard() {
@@ -25,7 +27,7 @@ function SensorDashboard() {
         lux: { value: 0, unit: "lux" },
         tds: { value: 0, unit: "ppm" },
         ec: { value: 0, unit: "mS/cm" },
-        health: { veml7700: false, as7341: false, sht3x: false },
+        health: { veml7700: false, as7341: false, sht3x: false, tds: false, ph: false },
     });
     const [dailyData, setDailyData] = useState(() => {
         const stored = localStorage.getItem("dailyData");

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -64,6 +64,43 @@ test('parses numeric strings into numbers', () => {
     expect(result.lux.value).toBe(30);
 });
 
+test('normalizes sensors array structure', () => {
+    const raw = {
+        sensors: [
+            { type: 'temperature', value: 26.5, unit: '°C' },
+            { type: 'humidity', value: 50, unit: '%' },
+            { type: 'light', value: 9, unit: 'lux' },
+            {
+                type: 'colorSpectrum',
+                value: {
+                    '415nm': 3,
+                    '445nm': 4,
+                    '480nm': 7,
+                    '515nm': 9,
+                    '555nm': 15,
+                    '590nm': 24,
+                    '630nm': 27,
+                    '680nm': 26
+                },
+                unit: 'raw'
+            },
+            { type: 'tds', value: 89, unit: 'ppm' },
+            { type: 'ec', value: 0.14, unit: 'mS/cm' }
+        ],
+        health: { sht3x: true, veml7700: true, as7341: true, tds: true, ph: false }
+    };
+    const result = normalizeSensorData(raw);
+    expect(result.F1).toBe(3);
+    expect(result.F8).toBe(26);
+    expect(result.temperature.value).toBe(26.5);
+    expect(result.humidity.value).toBe(50);
+    expect(result.lux.value).toBe(9);
+    expect(result.tds.value).toBe(89);
+    expect(result.ec.value).toBe(0.14);
+    expect(result.health.tds).toBe(true);
+    expect(result.health.ph).toBe(false);
+});
+
 test('filterNoise discards out of range values', () => {
     const clean = {
         F1: 100, F2: 100, F3: 100, F4: 100,


### PR DESCRIPTION
## Summary
- support new sensor types (tds, ec, ph) in the dashboard
- add test for sensors array JSON structure
- fix newline at end of SensorDashboard

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a56c233b883288eba92e19165045f