### PR TITLE
Update ideal ranges and sensor card styling

### DIFF
--- a/src/components/SensorCard.jsx
+++ b/src/components/SensorCard.jsx
@@ -1,12 +1,76 @@
 import React from 'react';
 import styles from './SensorCard.module.css';
+import idealRanges from '../idealRangeConfig';
 
-function SensorCard({ name, ok, children }) {
-    const headerClass = `${styles.header} ${ok ? styles.on : styles.off}`;
+const bandMap = {
+    F1: '415nm',
+    F2: '445nm',
+    F3: '480nm',
+    F4: '515nm',
+    F5: '555nm',
+    F6: '590nm',
+    F7: '630nm',
+    F8: '680nm'
+};
+
+function getRowColor(value, range) {
+    if (!range) return '';
+    if (value < range.min || value > range.max) return '#f8d7da';
+    if (value < range.min + 10 || value > range.max - 10) return '#fff3cd';
+    return '';
+}
+
+function SensorCard({ name, ok, fields = [], sensorData }) {
+    const descriptions = [];
+
+    const rows = fields.map(field => {
+        const lookup = bandMap[field] || field;
+        const data = sensorData[field];
+        const value =
+            data && typeof data === 'object' && 'value' in data ? data.value : data;
+        const display = typeof value === 'number' ? value.toFixed(1) : value;
+        const unit = data && typeof data === 'object' ? data.unit || '' : '';
+        const cfg = idealRanges[lookup];
+        if (cfg?.description) {
+            descriptions.push(`${lookup}: ${cfg.description}`);
+        }
+        return (
+            <tr
+                key={field}
+                style={{ backgroundColor: getRowColor(value, cfg?.idealRange) }}
+            >
+                <td>{lookup}</td>
+                <td>
+                    {display} {unit}
+                </td>
+                <td>{cfg?.idealRange?.min ?? '-'}</td>
+                <td>{cfg?.idealRange?.max ?? '-'}</td>
+            </tr>
+        );
+    });
+
     return (
         <div className={styles.card}>
-            <div className={headerClass}>{name}: {ok ? 'On' : 'Off'}</div>
-            <div className={styles.body}>{children}</div>
+            <div className={styles.header}>
+                <span className={styles.name}>{name.toUpperCase()}</span>
+                <span className={`${styles.indicator} ${ok ? styles.on : styles.off}`} />
+            </div>
+            <div className={styles.body}>
+                <table className={styles.table}>
+                    <thead>
+                        <tr>
+                            <th>Field</th>
+                            <th>Value</th>
+                            <th>Min</th>
+                            <th>Max</th>
+                        </tr>
+                    </thead>
+                    <tbody>{rows}</tbody>
+                </table>
+                {descriptions.length > 0 && (
+                    <div className={styles.note}>{descriptions.join(' ')}</div>
+                )}
+            </div>
         </div>
     );
 }

--- a/src/components/SensorCard.module.css
+++ b/src/components/SensorCard.module.css
@@ -2,14 +2,29 @@
     border: 1px solid #ccc;
     border-radius: 4px;
     overflow: hidden;
-    width: 200px;
+    width: 220px;
     margin: 10px;
 }
 
 .header {
-    color: white;
-    text-align: center;
-    padding: 4px 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    background-color: #eef6ff;
+    padding: 8px 12px;
+    font-weight: bold;
+}
+
+.name {
+    text-transform: uppercase;
+}
+
+.indicator {
+    border-radius: 50%;
+    width: 18px;
+    height: 18px;
+    margin-left: 8px;
 }
 
 .on {
@@ -22,5 +37,22 @@
 
 .body {
     padding: 8px;
+}
+
+.table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.table th,
+.table td {
+    border: 1px solid #ddd;
+    padding: 4px;
+    text-align: center;
+}
+
+.note {
+    margin-top: 8px;
+    font-size: 0.8em;
 }
 

--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -140,21 +140,13 @@ function SensorDashboard() {
 
             <div className={styles.sensorGrid}>
                 {Object.entries(sensorData.health).map(([name, ok]) => (
-                    <SensorCard key={name} name={name} ok={ok}>
-                        {sensorFieldMap[name]?.map(field => {
-                            const data = sensorData[field];
-                            const value = (data && typeof data === 'object' && 'value' in data)
-                                ? data.value
-                                : data;
-                            const display = typeof value === 'number' ? value.toFixed(1) : value;
-                            const unit = (data && typeof data === 'object') ? (data.unit || '') : '';
-                            return (
-                                <div key={field}>
-                                    {field}: {display} {unit}
-                                </div>
-                            );
-                        })}
-                    </SensorCard>
+                    <SensorCard
+                        key={name}
+                        name={name}
+                        ok={ok}
+                        fields={sensorFieldMap[name] || []}
+                        sensorData={sensorData}
+                    />
                 ))}
             </div>
 

--- a/src/idealRangeConfig.js
+++ b/src/idealRangeConfig.js
@@ -1,0 +1,68 @@
+const idealRangeConfig = {
+    temperature: {
+        idealRange: { min: 20, max: 30 },
+        description: 'Ideal range for basil growth is 20\u201330\xB0C. Below 18\xB0C or above 32\xB0C may slow growth.'
+    },
+    humidity: {
+        idealRange: { min: 50, max: 70 },
+        description: 'Best humidity for basil is between 50% and 70%. Too dry or too wet affects leaf quality.'
+    },
+    lux: {
+        idealRange: { min: 800, max: 2000 },
+        description: 'Basil needs strong light. 800\u20132000 lux is ideal for indoor growth.'
+    },
+    tds: {
+        idealRange: { min: 700, max: 1200 },
+        description: 'TDS level shows nutrient concentration. Below 600 = weak; above 1400 = overfed.'
+    },
+    ec: {
+        idealRange: { min: 1.1, max: 1.8 },
+        description: 'EC is based on TDS. 1.1\u20131.8 mS/cm is ideal for basil in hydroponics.'
+    },
+    ph: {
+        idealRange: { min: 5.8, max: 6.5 },
+        description: 'pH affects nutrient absorption. 6.0 is optimal for basil.'
+    },
+    '415nm': {
+        idealRange: { min: 100, max: 500 },
+        description: 'Supports early cell growth.'
+    },
+    '445nm': {
+        idealRange: { min: 200, max: 600 },
+        description: 'Key for chlorophyll and leafy growth.'
+    },
+    '480nm': {
+        idealRange: { min: 150, max: 500 },
+        description: 'Blue-green light; supports vegetative growth and pigment production.'
+    },
+    '515nm': {
+        idealRange: { min: 120, max: 400 },
+        description: 'Green light; penetrates deeper into leaves and regulates growth balance.'
+    },
+    '555nm': {
+        idealRange: { min: 80, max: 350 },
+        description: 'Mid-green light; complements blue and red for fuller spectrum balance.'
+    },
+    '590nm': {
+        idealRange: { min: 100, max: 300 },
+        description: 'Yellow light; minor effect on photosynthesis but supports photomorphogenesis.'
+    },
+    '630nm': {
+        idealRange: { min: 300, max: 800 },
+        description: 'Helps in flowering and general development.'
+    },
+    '680nm': {
+        idealRange: { min: 400, max: 900 },
+        description: 'Peak light absorption for photosynthesis.'
+    },
+    clear: {
+        idealRange: { min: 500, max: 2000 },
+        description: 'Total visible light intensity. General index of light.'
+    },
+    nir: {
+        idealRange: { min: 0, max: 200 },
+        description: 'Higher NIR may indicate heat. Keep it low indoors.'
+    }
+};
+
+export default idealRangeConfig;


### PR DESCRIPTION
## Summary
- refresh idealRangeConfig with wavelength keys and new ranges
- map F1–F8 to wavelengths in SensorCard
- show the mapped key names in the table
- add a light header background for SensorCard

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b4e1dfc8c83288ffecefdc67f4a1f