### PR TITLE
Fix chart labels

### DIFF
--- a/src/components/DailyTemperatureChart.jsx
+++ b/src/components/DailyTemperatureChart.jsx
@@ -53,7 +53,7 @@ const DailyTemperatureChart = ({
                 scale="time"
             />
             <YAxis>
-                <Label value="Temp (°C) / Humidity (%)" angle={-90} position="insideLeft" />
+                <Label value="Temp (°C) / Humidity (%)" angle={-90} position="insideLeft" style={{ textAnchor: 'middle' }} />
             </YAxis>
             {(() => {
                 const tRange = idealRanges.temperature?.idealRange;

--- a/src/components/MultiBandChart.jsx
+++ b/src/components/MultiBandChart.jsx
@@ -64,7 +64,7 @@ const MultiBandChart = ({
                     scale="time"
                 />
                 <YAxis domain={yDomain} allowDataOverflow>
-                    <Label value="Spectrum Value" angle={-90} position="insideLeft" />
+                    <Label value="Spectrum Value" angle={-90} position="insideLeft" style={{ textAnchor: 'middle' }} />
                 </YAxis>
                 {bandKeys.map((key, idx) => {
                     const range = idealRanges[key]?.idealRange;

--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -36,7 +36,9 @@ function SensorDashboard() {
         localStorage.setItem("dailyData", JSON.stringify(initial));
         return initial;
     });
-    const [timeRange, setTimeRange] = useState('24h');
+    const [timeRange, setTimeRange] = useState(() => {
+        return localStorage.getItem('timeRange') || '24h';
+    });
     const [rangeData, setRangeData] = useState([]);
     const [tempRangeData, setTempRangeData] = useState([]);
     const [xDomain, setXDomain] = useState([Date.now() - 24 * 60 * 60 * 1000, Date.now()]);
@@ -83,6 +85,10 @@ function SensorDashboard() {
 
     useEffect(() => {
         applyFilter();
+    }, [timeRange]);
+
+    useEffect(() => {
+        localStorage.setItem('timeRange', timeRange);
     }, [timeRange]);
 
     useEffect(() => {
@@ -154,22 +160,25 @@ function SensorDashboard() {
                 <SpectrumBarChart sensorData={sensorData} />
             </div>
 
-            <div className={styles.filterRow}>
-                <label>
-                    Range:
-                    <select value={timeRange} onChange={e => setTimeRange(e.target.value)}>
-                        <option value="6h">6h</option>
-                        <option value="12h">12h</option>
-                        <option value="24h">24h</option>
-                        <option value="3days">3 days</option>
-                        <option value="7days">7 days</option>
-                        <option value="1month">1 month</option>
-                    </select>
-                </label>
-            </div>
-            <div className={styles.rangeLabel}>
-                {`From: ${formatTime(startTime)} until: ${formatTime(endTime)}`}
-            </div>
+            <fieldset className={styles.historyControls}>
+                <legend className={styles.historyLegend}>Historical Range</legend>
+                <div className={styles.filterRow}>
+                    <label>
+                        Range:
+                        <select value={timeRange} onChange={e => setTimeRange(e.target.value)}>
+                            <option value="6h">6h</option>
+                            <option value="12h">12h</option>
+                            <option value="24h">24h</option>
+                            <option value="3days">3 days</option>
+                            <option value="7days">7 days</option>
+                            <option value="1month">1 month</option>
+                        </select>
+                    </label>
+                </div>
+                <div className={styles.rangeLabel}>
+                    {`From: ${formatTime(startTime)} until: ${formatTime(endTime)}`}
+                </div>
+            </fieldset>
 
             <h3 className={styles.sectionTitle}>Temperature</h3>
             <div className={styles.dailyTempChartWrapper}>

--- a/src/components/SensorDashboard.module.css
+++ b/src/components/SensorDashboard.module.css
@@ -9,9 +9,19 @@
 }
 .sectionTitle {
     margin-top: 40px;
+    text-align: center;
 }
 .filterRow {
     margin-bottom: 10px;
+}
+.historyControls {
+    border: 1px solid #ccc;
+    padding: 10px;
+    margin-bottom: 20px;
+}
+.historyLegend {
+    font-weight: bold;
+    padding: 0 5px;
 }
 .filterLabel {
     margin-left: 10px;


### PR DESCRIPTION
## Summary
- center chart section titles
- center Y-axis labels on Temperature and Historical Bands charts
- persist selected history range using `localStorage`
- group range controls in a fieldset with legend

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ba7725afc832897cc2e101ad9082d