### PR TITLE
Add pH sensor support

### DIFF
--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -15,7 +15,7 @@ const sensorFieldMap = {
     sht3x: ['temperature', 'humidity'],
     as7341: ['F1','F2','F3','F4','F5','F6','F7','F8','clear','nir'],
     tds: ['tds', 'ec'],
-    ph: []
+    ph: ['ph']
 };
 
 function SensorDashboard() {
@@ -27,6 +27,7 @@ function SensorDashboard() {
         lux: { value: 0, unit: "lux" },
         tds: { value: 0, unit: "ppm" },
         ec: { value: 0, unit: "mS/cm" },
+        ph: { value: 0, unit: '' },
         health: { veml7700: false, as7341: false, sht3x: false, tds: false, ph: false },
     });
     const [dailyData, setDailyData] = useState(() => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -17,6 +17,7 @@ export function normalizeSensorData(data) {
         lux: { value: 0, unit: "lux" },
         tds: { value: 0, unit: "ppm" },
         ec: { value: 0, unit: "mS/cm" },
+        ph: { value: 0, unit: '' },
         F1: 0, F2: 0, F3: 0, F4: 0, F5: 0,
         F6: 0, F7: 0, F8: 0, clear: 0, nir: 0,
         health: {}
@@ -51,6 +52,12 @@ export function normalizeSensorData(data) {
                         unit: sensor.unit || ''
                 };
                 break;
+            case 'ph':
+                result.ph = {
+                        value: val,
+                        unit: sensor.unit || ''
+                };
+                break;
             case 'colorSpectrum':
                     const bands = ['F1','F2','F3','F4','F5','F6','F7','F8','clear','nir'];
                 let i = 0;
@@ -73,6 +80,8 @@ export function normalizeSensorData(data) {
             result.tds = { value: Number(data.tds), unit: 'ppm' };
         if ('ec' in data)
             result.ec = { value: Number(data.ec), unit: 'mS/cm' };
+        if ('ph' in data)
+            result.ph = { value: Number(data.ph), unit: '' };
 
         const mapping = {
             ch415: 'F1', ch445: 'F2', ch480: 'F3', ch515: 'F4',

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -101,6 +101,16 @@ test('normalizes sensors array structure', () => {
     expect(result.health.ph).toBe(false);
 });
 
+test('handles ph sensor readings', () => {
+    const raw = {
+        sensors: [
+            { type: 'ph', value: 6.2, unit: '' }
+        ]
+    };
+    const result = normalizeSensorData(raw);
+    expect(result.ph.value).toBe(6.2);
+});
+
 test('filterNoise discards out of range values', () => {
     const clean = {
         F1: 100, F2: 100, F3: 100, F4: 100,


### PR DESCRIPTION
## Summary
- display pH data in dashboard sensor card
- parse `ph` values in sensor utils
- add unit test coverage for pH

## Testing
- `npm install` *(fails: network restricted)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bad07770483288c21ed4b35ac9b90