### PR TITLE
Improve dashboard layout

### DIFF
--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -143,55 +143,67 @@ function SensorDashboard() {
 
     return (
         <div className={styles.dashboard}>
-            <Header topic={topic} />
+            <div className={styles.section}>
+                <h2 className={styles.sectionHeader}>Live Data</h2>
+                <div className={styles.sectionBody}>
+                    <Header topic={topic} />
 
-            <div className={styles.sensorGrid}>
-                {Object.entries(sensorData.health).map(([name, ok]) => (
-                    <SensorCard
-                        key={name}
-                        name={name}
-                        ok={ok}
-                        fields={sensorFieldMap[name] || []}
-                        sensorData={sensorData}
-                    />
-                ))}
-            </div>
+                    <div className={styles.sensorGrid}>
+                        {Object.entries(sensorData.health).map(([name, ok]) => (
+                            <SensorCard
+                                key={name}
+                                name={name}
+                                ok={ok}
+                                fields={sensorFieldMap[name] || []}
+                                sensorData={sensorData}
+                            />
+                        ))}
+                    </div>
 
-            <div className={styles.spectrumBarChartWrapper}>
-                <SpectrumBarChart sensorData={sensorData} />
-            </div>
-
-            <fieldset className={styles.historyControls}>
-                <legend className={styles.historyLegend}>Historical Range</legend>
-                <div className={styles.filterRow}>
-                    <label>
-                        Range:
-                        <select value={timeRange} onChange={e => setTimeRange(e.target.value)}>
-                            <option value="6h">6h</option>
-                            <option value="12h">12h</option>
-                            <option value="24h">24h</option>
-                            <option value="3days">3 days</option>
-                            <option value="7days">7 days</option>
-                            <option value="1month">1 month</option>
-                        </select>
-                    </label>
+                    <div className={styles.spectrumBarChartWrapper}>
+                        <SpectrumBarChart sensorData={sensorData} />
+                    </div>
                 </div>
-                <div className={styles.rangeLabel}>
-                    {`From: ${formatTime(startTime)} until: ${formatTime(endTime)}`}
-                </div>
-            </fieldset>
-
-            <h3 className={styles.sectionTitle}>Temperature</h3>
-            <div className={styles.dailyTempChartWrapper}>
-                <HistoricalTemperatureChart data={tempRangeData} xDomain={xDomain} />
             </div>
 
-            <h3 className={styles.sectionTitle}>Historical Bands</h3>
-            <div className={styles.multiBandChartWrapper}>
-                <HistoricalMultiBandChart
-                    data={rangeData}
-                    xDomain={xDomain}
-                />
+            <div className={styles.divider}></div>
+
+            <div className={styles.section}>
+                <h2 className={styles.sectionHeader}>Reports</h2>
+                <div className={styles.sectionBody}>
+                    <fieldset className={styles.historyControls}>
+                        <legend className={styles.historyLegend}>Historical Range</legend>
+                        <div className={styles.filterRow}>
+                            <label>
+                                Range:
+                                <select value={timeRange} onChange={e => setTimeRange(e.target.value)}>
+                                    <option value="6h">6h</option>
+                                    <option value="12h">12h</option>
+                                    <option value="24h">24h</option>
+                                    <option value="3days">3 days</option>
+                                    <option value="7days">7 days</option>
+                                    <option value="1month">1 month</option>
+                                </select>
+                            </label>
+                        </div>
+                        <div className={styles.rangeLabel}>
+                            {`From: ${formatTime(startTime)} until: ${formatTime(endTime)}`}
+                        </div>
+                    </fieldset>
+
+                    <h3 className={styles.sectionTitle}>Temperature</h3>
+                    <div className={styles.dailyTempChartWrapper}>
+                        <HistoricalTemperatureChart data={tempRangeData} xDomain={xDomain} />
+                    </div>
+
+                    <h3 className={styles.sectionTitle}>Historical Bands</h3>
+                    <div className={styles.multiBandChartWrapper}>
+                        <HistoricalMultiBandChart
+                            data={rangeData}
+                            xDomain={xDomain}
+                        />
+                    </div>
+                </div>
             </div>
         </div>
     );

--- a/src/components/SensorDashboard.module.css
+++ b/src/components/SensorDashboard.module.css
@@ -1,6 +1,26 @@
 .dashboard {
     padding: 20px;
 }
+
+.section {
+    margin-bottom: 40px;
+}
+
+.sectionHeader {
+    text-align: center;
+    font-size: 1.5em;
+    margin-bottom: 10px;
+}
+
+.sectionBody {
+    border: 1px solid #ddd;
+    padding: 20px;
+}
+
+.divider {
+    border-bottom: 2px solid #ccc;
+    margin: 40px 0;
+}
 .sensorGrid {
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- split the dashboard into two sections
- style sections and divider for clarity

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bbd42a72483288486bd35c45501e9