### PR TITLE
UI update for historical section

### DIFF
--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -190,17 +190,22 @@ function SensorDashboard() {
                         </div>
                     </fieldset>
 
-                    <h3 className={styles.sectionTitle}>Temperature</h3>
-                    <div className={styles.dailyTempChartWrapper}>
-                        <HistoricalTemperatureChart data={tempRangeData} xDomain={xDomain} />
-                    </div>
-
-                    <h3 className={styles.sectionTitle}>Historical Bands</h3>
-                    <div className={styles.multiBandChartWrapper}>
-                        <HistoricalMultiBandChart
-                            data={rangeData}
-                            xDomain={xDomain}
-                        />
+                    <div className={styles.historyChartsRow}>
+                        <div className={styles.historyChartColumn}>
+                            <h3 className={styles.sectionTitle}>Temperature</h3>
+                            <div className={styles.dailyTempChartWrapper}>
+                                <HistoricalTemperatureChart data={tempRangeData} xDomain={xDomain} />
+                            </div>
+                        </div>
+                        <div className={styles.historyChartColumn}>
+                            <h3 className={styles.sectionTitle}>Historical Bands</h3>
+                            <div className={styles.multiBandChartWrapper}>
+                                <HistoricalMultiBandChart
+                                    data={rangeData}
+                                    xDomain={xDomain}
+                                />
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/components/SensorDashboard.module.css
+++ b/src/components/SensorDashboard.module.css
@@ -51,10 +51,12 @@
     border: 1px solid #ccc;
     padding: 10px;
     margin-bottom: 20px;
+    background-color: #eef6ff;
 }
 .historyLegend {
     font-weight: bold;
     padding: 0 5px;
+    background-color: #eef6ff;
 }
 .filterLabel {
     margin-left: 10px;
@@ -83,16 +85,29 @@
     width: 100%;
 }
 
+.historyChartsRow {
+    display: flex;
+    flex-direction: column;
+    gap: 40px;
+}
+
+.historyChartColumn {
+    width: 100%;
+}
+
 @media (min-width: 1000px) {
-    .multiBandChartWrapper {
+    .historyChartsRow {
+        flex-direction: row;
+    }
+    .historyChartColumn {
         width: 50%;
-        margin: 0 auto;
+    }
+    .multiBandChartWrapper,
+    .dailyTempChartWrapper {
+        width: 100%;
+        margin: 0;
     }
     .spectrumBarChartWrapper {
-        width: 50%;
-        margin: 0 auto;
-    }
-    .dailyTempChartWrapper {
         width: 50%;
         margin: 0 auto;
     }


### PR DESCRIPTION
## Summary
- style historical range like sensor card header
- place historical charts side-by-side on wide screens

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bc221d2008328a0cfaf4453a0827f