### PR TITLE
Add pH and EC/TDS historical charts

### DIFF
--- a/src/components/HistoricalEcTdsChart.jsx
+++ b/src/components/HistoricalEcTdsChart.jsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import idealRanges from '../idealRangeConfig';
+import {
+    LineChart,
+    Line,
+    XAxis,
+    YAxis,
+    CartesianGrid,
+    Tooltip,
+    Label,
+    ReferenceArea,
+    Legend,
+    ResponsiveContainer,
+} from 'recharts';
+
+const HistoricalEcTdsChart = ({
+    data,
+    width = 600,
+    height = 300,
+    xDomain = [Date.now() - 24 * 60 * 60 * 1000, Date.now()],
+}) => {
+    const start = xDomain[0];
+    const end = xDomain[1];
+    const day = 24 * 60 * 60 * 1000;
+    const hour = 60 * 60 * 1000;
+    const interval = end - start <= day * 2 ? hour : day;
+    const ticks = [];
+    for (let t = Math.ceil(start / interval) * interval; t <= end; t += interval) {
+        ticks.push(t);
+    }
+    const tickFormatter = val => {
+        const d = new Date(val);
+        return end - start <= day * 2
+            ? `${String(d.getHours()).padStart(2, '0')}`
+            : `${d.getMonth() + 1}/${d.getDate()}`;
+    };
+
+    const ecRange = idealRanges.ec?.idealRange;
+    const tdsRange = idealRanges.tds?.idealRange;
+
+    return (
+        <ResponsiveContainer width="100%" height={height} debounce={200}>
+            <LineChart
+                width={width}
+                height={height}
+                data={data}
+                margin={{ top: 20, right: 30, left: 0, bottom: 50 }}
+                isAnimationActive={false}
+            >
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis
+                    dataKey="time"
+                    type="number"
+                    domain={xDomain}
+                    ticks={ticks}
+                    tickFormatter={tickFormatter}
+                    scale="time"
+                />
+                <YAxis yAxisId="left">
+                    <Label value="TDS (ppm)" angle={-90} position="insideLeft" style={{ textAnchor: 'middle' }} />
+                </YAxis>
+                <YAxis yAxisId="right" orientation="right">
+                    <Label value="EC (mS/cm)" angle={-90} position="insideRight" style={{ textAnchor: 'middle' }} />
+                </YAxis>
+                {tdsRange && (
+                    <ReferenceArea
+                        yAxisId="left"
+                        y1={tdsRange.min}
+                        y2={tdsRange.max}
+                        x1={start}
+                        x2={end}
+                        fill="rgba(0,123,255,0.1)"
+                        stroke="none"
+                    />
+                )}
+                {ecRange && (
+                    <ReferenceArea
+                        yAxisId="right"
+                        y1={ecRange.min}
+                        y2={ecRange.max}
+                        x1={start}
+                        x2={end}
+                        fill="rgba(255,193,7,0.1)"
+                        stroke="none"
+                    />
+                )}
+                <Tooltip />
+                <Legend />
+                <Line
+                    yAxisId="left"
+                    type="monotone"
+                    dataKey="tds"
+                    stroke="#007bff"
+                    dot={false}
+                    isAnimationActive={false}
+                />
+                <Line
+                    yAxisId="right"
+                    type="monotone"
+                    dataKey="ec"
+                    stroke="#ffc107"
+                    dot={false}
+                    isAnimationActive={false}
+                />
+            </LineChart>
+        </ResponsiveContainer>
+    );
+};
+
+export default React.memo(HistoricalEcTdsChart);

--- a/src/components/HistoricalPhChart.jsx
+++ b/src/components/HistoricalPhChart.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import idealRanges from '../idealRangeConfig';
+import {
+    LineChart,
+    Line,
+    XAxis,
+    YAxis,
+    CartesianGrid,
+    Tooltip,
+    Label,
+    ReferenceArea,
+    ResponsiveContainer,
+} from 'recharts';
+
+const HistoricalPhChart = ({
+    data,
+    width = 600,
+    height = 300,
+    xDomain = [Date.now() - 24 * 60 * 60 * 1000, Date.now()],
+}) => {
+    const start = xDomain[0];
+    const end = xDomain[1];
+    const day = 24 * 60 * 60 * 1000;
+    const hour = 60 * 60 * 1000;
+    const interval = end - start <= day * 2 ? hour : day;
+    const ticks = [];
+    for (let t = Math.ceil(start / interval) * interval; t <= end; t += interval) {
+        ticks.push(t);
+    }
+    const tickFormatter = val => {
+        const d = new Date(val);
+        return end - start <= day * 2
+            ? `${String(d.getHours()).padStart(2, '0')}`
+            : `${d.getMonth() + 1}/${d.getDate()}`;
+    };
+
+    const phRange = idealRanges.ph?.idealRange;
+
+    return (
+        <ResponsiveContainer width="100%" height={height} debounce={200}>
+            <LineChart
+                width={width}
+                height={height}
+                data={data}
+                margin={{ top: 20, right: 30, left: 0, bottom: 50 }}
+                isAnimationActive={false}
+            >
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis
+                    dataKey="time"
+                    type="number"
+                    domain={xDomain}
+                    ticks={ticks}
+                    tickFormatter={tickFormatter}
+                    scale="time"
+                />
+                <YAxis>
+                    <Label value="pH" angle={-90} position="insideLeft" style={{ textAnchor: 'middle' }} />
+                </YAxis>
+                {phRange && (
+                    <ReferenceArea
+                        y1={phRange.min}
+                        y2={phRange.max}
+                        x1={start}
+                        x2={end}
+                        fill="rgba(40,167,69,0.1)"
+                        stroke="none"
+                    />
+                )}
+                <Tooltip />
+                <Line
+                    type="monotone"
+                    dataKey="ph"
+                    stroke="#28a745"
+                    dot={false}
+                    isAnimationActive={false}
+                />
+            </LineChart>
+        </ResponsiveContainer>
+    );
+};
+
+export default React.memo(HistoricalPhChart);

--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -3,6 +3,8 @@ import mqtt from "mqtt";
 import SpectrumBarChart from "./SpectrumBarChart";
 import HistoricalTemperatureChart from "./HistoricalTemperatureChart";
 import HistoricalMultiBandChart from "./HistoricalMultiBandChart";
+import HistoricalPhChart from "./HistoricalPhChart";
+import HistoricalEcTdsChart from "./HistoricalEcTdsChart";
 import Header from "./Header";
 import SensorCard from "./SensorCard";
 import { trimOldEntries, normalizeSensorData, filterNoise } from "../utils";
@@ -42,6 +44,8 @@ function SensorDashboard() {
     });
     const [rangeData, setRangeData] = useState([]);
     const [tempRangeData, setTempRangeData] = useState([]);
+    const [phRangeData, setPhRangeData] = useState([]);
+    const [ecTdsRangeData, setEcTdsRangeData] = useState([]);
     const [xDomain, setXDomain] = useState([Date.now() - 24 * 60 * 60 * 1000, Date.now()]);
     const [startTime, setStartTime] = useState(xDomain[0]);
     const [endTime, setEndTime] = useState(xDomain[1]);
@@ -78,6 +82,15 @@ function SensorDashboard() {
             time: d.time,
             temperature: d.temperature?.value ?? 0,
             humidity: d.humidity?.value ?? 0,
+        })));
+        setPhRangeData(filtered.map(d => ({
+            time: d.time,
+            ph: d.ph?.value ?? 0,
+        })));
+        setEcTdsRangeData(filtered.map(d => ({
+            time: d.time,
+            ec: d.ec?.value ?? 0,
+            tds: d.tds?.value ?? 0,
         })));
         setXDomain([start, now]);
         setStartTime(start);
@@ -204,6 +217,20 @@ function SensorDashboard() {
                                     data={rangeData}
                                     xDomain={xDomain}
                                 />
+                            </div>
+                        </div>
+                    </div>
+                    <div className={styles.historyChartsRow}>
+                        <div className={styles.historyChartColumn}>
+                            <h3 className={styles.sectionTitle}>pH</h3>
+                            <div className={styles.phChartWrapper}>
+                                <HistoricalPhChart data={phRangeData} xDomain={xDomain} />
+                            </div>
+                        </div>
+                        <div className={styles.historyChartColumn}>
+                            <h3 className={styles.sectionTitle}>EC &amp; TDS</h3>
+                            <div className={styles.ecTdsChartWrapper}>
+                                <HistoricalEcTdsChart data={ecTdsRangeData} xDomain={xDomain} />
                             </div>
                         </div>
                     </div>

--- a/src/components/SensorDashboard.module.css
+++ b/src/components/SensorDashboard.module.css
@@ -85,6 +85,14 @@
     width: 100%;
 }
 
+.phChartWrapper {
+    width: 100%;
+}
+
+.ecTdsChartWrapper {
+    width: 100%;
+}
+
 .historyChartsRow {
     display: flex;
     flex-direction: column;
@@ -103,7 +111,9 @@
         width: 50%;
     }
     .multiBandChartWrapper,
-    .dailyTempChartWrapper {
+    .dailyTempChartWrapper,
+    .phChartWrapper,
+    .ecTdsChartWrapper {
         width: 100%;
         margin: 0;
     }

--- a/tests/HistoricalEcTdsChart.test.jsx
+++ b/tests/HistoricalEcTdsChart.test.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import HistoricalEcTdsChart from '../src/components/HistoricalEcTdsChart';
+import { vi } from 'vitest';
+
+vi.mock('../src/idealRangeConfig', () => ({
+    __esModule: true,
+    default: {
+        ec: { idealRange: { min: 1.1, max: 1.8 } },
+        tds: { idealRange: { min: 700, max: 1200 } },
+    },
+}));
+
+beforeAll(() => {
+    Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+        configurable: true,
+        value: 600,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+        configurable: true,
+        value: 300,
+    });
+});
+
+describe('HistoricalEcTdsChart', () => {
+    const mockData = [
+        { time: Date.now() - 3600 * 1000, ec: 1.4, tds: 850 },
+        { time: Date.now(), ec: 1.5, tds: 900 },
+    ];
+
+    it('renders without crashing', () => {
+        render(<HistoricalEcTdsChart data={mockData} />);
+    });
+
+    it('renders a recharts container', () => {
+        const { container } = render(<HistoricalEcTdsChart data={mockData} />);
+        const rechartsWrapper = container.querySelector('.recharts-responsive-container');
+        expect(rechartsWrapper).toBeTruthy();
+    });
+});

--- a/tests/HistoricalPhChart.test.jsx
+++ b/tests/HistoricalPhChart.test.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import HistoricalPhChart from '../src/components/HistoricalPhChart';
+import { vi } from 'vitest';
+
+vi.mock('../src/idealRangeConfig', () => ({
+    __esModule: true,
+    default: {
+        ph: { idealRange: { min: 5.5, max: 6.5 } },
+    },
+}));
+
+beforeAll(() => {
+    Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+        configurable: true,
+        value: 600,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+        configurable: true,
+        value: 300,
+    });
+});
+
+describe('HistoricalPhChart', () => {
+    const mockData = [
+        { time: Date.now() - 3600 * 1000, ph: 6.2 },
+        { time: Date.now(), ph: 6.4 },
+    ];
+
+    it('renders without crashing', () => {
+        render(<HistoricalPhChart data={mockData} />);
+    });
+
+    it('renders a recharts container', () => {
+        const { container } = render(<HistoricalPhChart data={mockData} />);
+        const rechartsWrapper = container.querySelector('.recharts-responsive-container');
+        expect(rechartsWrapper).toBeTruthy();
+    });
+});


### PR DESCRIPTION
## Summary
- implement `HistoricalPhChart` component
- implement `HistoricalEcTdsChart` component
- show new charts in `SensorDashboard`
- add wrappers to dashboard stylesheet
- test the new chart components

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bc3799e348328812e179e30b2a14d