### PR TITLE
Split multi band chart into three charts

### DIFF
--- a/src/components/HistoricalBlueBandChart.jsx
+++ b/src/components/HistoricalBlueBandChart.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import HistoricalMultiBandChart from './HistoricalMultiBandChart';
+
+const HistoricalBlueBandChart = (props) => (
+    <HistoricalMultiBandChart {...props} bandKeys={['F1','F2','F3','F4']} />
+);
+
+export default React.memo(HistoricalBlueBandChart);

--- a/src/components/HistoricalClearLuxChart.jsx
+++ b/src/components/HistoricalClearLuxChart.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import HistoricalMultiBandChart from './HistoricalMultiBandChart';
+
+const HistoricalClearLuxChart = (props) => (
+    <HistoricalMultiBandChart {...props} bandKeys={['clear','lux']} />
+);
+
+export default React.memo(HistoricalClearLuxChart);

--- a/src/components/HistoricalMultiBandChart.jsx
+++ b/src/components/HistoricalMultiBandChart.jsx
@@ -19,8 +19,8 @@ const colors = [
     '#A28EDB', '#FF6666'
 ];
 
-const bandKeys = [
-    'F1', 'F2', 'F3', 'F4', 'F5', 'F6', 'F7', 'F8', 'clear', 'nir'
+const defaultBandKeys = [
+    'F1', 'F2', 'F3', 'F4', 'F5', 'F6', 'F7', 'F8', 'clear', 'nir', 'lux'
 ];
 
 const bandMap = {
@@ -40,6 +40,7 @@ const HistoricalMultiBandChart = ({
     height = 300,
     xDomain = [Date.now() - 24 * 60 * 60 * 1000, Date.now()],
     yDomain,
+    bandKeys = defaultBandKeys,
 }) => {
     const processedData = React.useMemo(() => {
         return (data || []).map(entry => {

--- a/src/components/HistoricalRedBandChart.jsx
+++ b/src/components/HistoricalRedBandChart.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import HistoricalMultiBandChart from './HistoricalMultiBandChart';
+
+const HistoricalRedBandChart = (props) => (
+    <HistoricalMultiBandChart {...props} bandKeys={['F5','F6','F7','F8','nir']} />
+);
+
+export default React.memo(HistoricalRedBandChart);

--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -2,7 +2,9 @@ import React, { useEffect, useState, useMemo } from "react";
 import mqtt from "mqtt";
 import SpectrumBarChart from "./SpectrumBarChart";
 import HistoricalTemperatureChart from "./HistoricalTemperatureChart";
-import HistoricalMultiBandChart from "./HistoricalMultiBandChart";
+import HistoricalBlueBandChart from "./HistoricalBlueBandChart";
+import HistoricalRedBandChart from "./HistoricalRedBandChart";
+import HistoricalClearLuxChart from "./HistoricalClearLuxChart";
 import HistoricalPhChart from "./HistoricalPhChart";
 import HistoricalEcTdsChart from "./HistoricalEcTdsChart";
 import Header from "./Header";
@@ -212,11 +214,14 @@ function SensorDashboard() {
                         </div>
                         <div className={styles.historyChartColumn}>
                             <h3 className={styles.sectionTitle}>Historical Bands</h3>
-                            <div className={styles.multiBandChartWrapper}>
-                                <HistoricalMultiBandChart
-                                    data={rangeData}
-                                    xDomain={xDomain}
-                                />
+                            <div className={styles.blueBandChartWrapper}>
+                                <HistoricalBlueBandChart data={rangeData} xDomain={xDomain} />
+                            </div>
+                            <div className={styles.redBandChartWrapper}>
+                                <HistoricalRedBandChart data={rangeData} xDomain={xDomain} />
+                            </div>
+                            <div className={styles.clearLuxChartWrapper}>
+                                <HistoricalClearLuxChart data={rangeData} xDomain={xDomain} />
                             </div>
                         </div>
                     </div>

--- a/src/components/SensorDashboard.module.css
+++ b/src/components/SensorDashboard.module.css
@@ -77,6 +77,12 @@
     width: 100%;
 }
 
+.blueBandChartWrapper,
+.redBandChartWrapper,
+.clearLuxChartWrapper {
+    width: 100%;
+}
+
 .spectrumBarChartWrapper {
     width: 100%;
 }
@@ -111,6 +117,9 @@
         width: 50%;
     }
     .multiBandChartWrapper,
+    .blueBandChartWrapper,
+    .redBandChartWrapper,
+    .clearLuxChartWrapper,
     .dailyTempChartWrapper,
     .phChartWrapper,
     .ecTdsChartWrapper {

--- a/tests/HistoricalBlueBandChart.test.jsx
+++ b/tests/HistoricalBlueBandChart.test.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/react';
-import HistoricalMultiBandChart from '../src/components/HistoricalMultiBandChart';
+import HistoricalBlueBandChart from '../src/components/HistoricalBlueBandChart';
 
-describe('HistoricalMultiBandChart', () => {
+describe('HistoricalBlueBandChart', () => {
     const now = Date.now();
     const mockData = [
         {
@@ -23,7 +23,7 @@ describe('HistoricalMultiBandChart', () => {
     ];
 
     it('renders without crashing', () => {
-        const { container } = render(<HistoricalMultiBandChart data={mockData} />);
+        const { container } = render(<HistoricalBlueBandChart data={mockData} />);
         expect(container).toBeTruthy();
     });
 });


### PR DESCRIPTION
## Summary
- add ability to configure band keys in `HistoricalMultiBandChart`
- add `HistoricalBlueBandChart`, `HistoricalRedBandChart`, and `HistoricalClearLuxChart`
- update `SensorDashboard` to use new band charts
- adjust dashboard styles for new chart wrappers
- rename multiband chart test to test the blue band chart

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c68ff9c7083288702aa1e78e57c11