### PR TITLE
Update responsive layout

### DIFF
--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -213,23 +213,28 @@ function SensorDashboard() {
                             </div>
                         </div>
                         <div className={styles.historyChartColumn}>
-                            <h3 className={styles.sectionTitle}>Historical Bands</h3>
-                            <div className={styles.bandChartsGrid}>
-                                <div className={styles.blueBandChartWrapper}>
-                                    <h4 className={styles.chartTitle}>Blue Bands</h4>
-                                    <HistoricalBlueBandChart data={rangeData} xDomain={xDomain} />
-                                </div>
-                                <div className={styles.redBandChartWrapper}>
-                                    <h4 className={styles.chartTitle}>Red Bands</h4>
-                                    <HistoricalRedBandChart data={rangeData} xDomain={xDomain} />
-                                </div>
-                                <div className={styles.clearLuxChartWrapper}>
-                                    <h4 className={styles.chartTitle}>Lux_Clear</h4>
-                                    <HistoricalClearLuxChart data={rangeData} xDomain={xDomain} />
-                                </div>
+                            <h3 className={styles.sectionTitle}>Blue Bands</h3>
+                            <div className={styles.blueBandChartWrapper}>
+                                <HistoricalBlueBandChart data={rangeData} xDomain={xDomain} />
                             </div>
                         </div>
                     </div>
+
+                    <div className={styles.historyChartsRow}>
+                        <div className={styles.historyChartColumn}>
+                            <h3 className={styles.sectionTitle}>Red Bands</h3>
+                            <div className={styles.redBandChartWrapper}>
+                                <HistoricalRedBandChart data={rangeData} xDomain={xDomain} />
+                            </div>
+                        </div>
+                        <div className={styles.historyChartColumn}>
+                            <h3 className={styles.sectionTitle}>Lux_Clear</h3>
+                            <div className={styles.clearLuxChartWrapper}>
+                                <HistoricalClearLuxChart data={rangeData} xDomain={xDomain} />
+                            </div>
+                        </div>
+                    </div>
+
                     <div className={styles.historyChartsRow}>
                         <div className={styles.historyChartColumn}>
                             <h3 className={styles.sectionTitle}>pH</h3>

--- a/src/components/SensorDashboard.module.css
+++ b/src/components/SensorDashboard.module.css
@@ -83,22 +83,8 @@
     width: 100%;
 }
 
-.bandChartsGrid {
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: 20px;
-}
 
-.chartTitle {
-    margin: 0 0 10px;
-    text-align: center;
-}
 
-@media (min-width: 600px) {
-    .bandChartsGrid {
-        grid-template-columns: repeat(2, 1fr);
-    }
-}
 
 .spectrumBarChartWrapper {
     width: 100%;
@@ -126,7 +112,7 @@
     width: 100%;
 }
 
-@media (min-width: 1000px) {
+@media (min-width: 768px) {
     .historyChartsRow {
         flex-direction: row;
     }


### PR DESCRIPTION
## Summary
- restructure historical charts so each row has two equal-width charts
- remove unused band chart grid styles

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c711756f483289753f6a4980a11e5