### PR TITLE
Handle malformed JSON in MQTT messages

### DIFF
--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -9,7 +9,7 @@ import HistoricalPhChart from "./HistoricalPhChart";
 import HistoricalEcTdsChart from "./HistoricalEcTdsChart";
 import Header from "./Header";
 import SensorCard from "./SensorCard";
-import { trimOldEntries, normalizeSensorData, filterNoise } from "../utils";
+import { trimOldEntries, normalizeSensorData, filterNoise, parseSensorJson } from "../utils";
 import styles from './SensorDashboard.module.css';
 
 const topic = "azadFarm/sensorData";
@@ -133,7 +133,7 @@ function SensorDashboard() {
                 try {
                     console.log("message: "+message);
                     console.log(message.toString());
-                    const raw = JSON.parse(message.toString());
+                    const raw = parseSensorJson(message.toString());
                     const normalized = normalizeSensorData(raw);
                     const cleaned = filterNoise(normalized);
                     if (!cleaned) return;

--- a/src/utils.js
+++ b/src/utils.js
@@ -103,3 +103,13 @@ export function normalizeSensorData(data) {
     return result;
 }
 
+export function parseSensorJson(str) {
+    try {
+        return JSON.parse(str);
+    } catch (e) {
+        // Attempt to fix missing commas between sensor objects
+        const fixed = str.replace(/}\s*{"sensorId":/g, '},{"sensorId":');
+        return JSON.parse(fixed);
+    }
+}
+

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,4 +1,4 @@
-import { trimOldEntries, normalizeSensorData, filterNoise } from '../src/utils';
+import { trimOldEntries, normalizeSensorData, filterNoise, parseSensorJson } from '../src/utils';
 
 function fixedNow(ms) {
     return 1721310000000; // زمان ثابت برای تست، برای جلوگیری از اختلاف میلی‌ثانیه‌ای
@@ -127,4 +127,12 @@ test('filterNoise discards out of range values', () => {
 
     const badHumidity = { ...clean, humidity: { value: 150, unit: '%' } };
     expect(filterNoise(badHumidity)).toBeNull();
+});
+
+test('parseSensorJson fixes missing commas between sensor objects', () => {
+    const malformed = '{"sensors":[{"sensorId":"a","type":"temperature","value":1}{"sensorId":"b","type":"humidity","value":2}]}';
+    const parsed = parseSensorJson(malformed);
+    expect(Array.isArray(parsed.sensors)).toBe(true);
+    expect(parsed.sensors.length).toBe(2);
+    expect(parsed.sensors[1].sensorId).toBe('b');
 });


### PR DESCRIPTION
## Summary
- add `parseSensorJson` helper to repair missing commas between sensor objects
- use the helper in `SensorDashboard` when parsing incoming MQTT messages
- test the new parser

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c7bf466608328aa41e4bd5f63877e