### PR TITLE
Fix lux chart crash

### DIFF
--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -78,7 +78,11 @@ function SensorDashboard() {
         const start = now - rangeMs;
         const filtered = dailyData
             .filter(d => d.timestamp >= start && d.timestamp <= now)
-            .map(d => ({ time: d.timestamp, ...d }));
+            .map(d => ({
+                time: d.timestamp,
+                ...d,
+                lux: d.lux?.value ?? 0,
+            }));
         setRangeData(filtered);
         setTempRangeData(filtered.map(d => ({
             time: d.time,


### PR DESCRIPTION
## Summary
- map lux values to numbers before passing data to charts

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cad21ad8083289162d4dce3bbf5e3