### PR TITLE
Ensure history charts auto-scale Y axis

### DIFF
--- a/src/components/HistoricalPhChart.jsx
+++ b/src/components/HistoricalPhChart.jsx
@@ -34,6 +34,16 @@ const HistoricalPhChart = ({
             : `${d.getMonth() + 1}/${d.getDate()}`;
     };
 
+    const computedMax = React.useMemo(() => {
+        let max = 0;
+        for (const entry of data || []) {
+            const v = Number(entry.ph);
+            if (v > max) max = v;
+        }
+        return max || 1;
+    }, [data]);
+    const yDomain = [0, computedMax];
+
     const phRange = idealRanges.ph?.idealRange;
 
     return (
@@ -54,7 +64,7 @@ const HistoricalPhChart = ({
                     tickFormatter={tickFormatter}
                     scale="time"
                 />
-                <YAxis>
+                <YAxis domain={yDomain} allowDataOverflow>
                     <Label value="pH" angle={-90} position="insideLeft" style={{ textAnchor: 'middle' }} />
                 </YAxis>
                 {phRange && (

--- a/src/components/HistoricalTemperatureChart.jsx
+++ b/src/components/HistoricalTemperatureChart.jsx
@@ -34,6 +34,18 @@ const HistoricalTemperatureChart = ({
             : `${d.getMonth() + 1}/${d.getDate()}`;
     };
 
+    const computedMax = React.useMemo(() => {
+        let max = 0;
+        for (const entry of data || []) {
+            const t = Number(entry.temperature);
+            const h = Number(entry.humidity);
+            if (t > max) max = t;
+            if (h > max) max = h;
+        }
+        return max || 1;
+    }, [data]);
+    const yDomain = [0, computedMax];
+
     return (
         <ResponsiveContainer width="100%" height={height} debounce={200}>
             <LineChart
@@ -52,7 +64,7 @@ const HistoricalTemperatureChart = ({
                 tickFormatter={tickFormatter}
                 scale="time"
             />
-            <YAxis>
+            <YAxis domain={yDomain} allowDataOverflow>
                 <Label value="Temp (°C) / Humidity (%)" angle={-90} position="insideLeft" style={{ textAnchor: 'middle' }} />
             </YAxis>
             {(() => {


### PR DESCRIPTION
## Summary
- compute maximum values in `HistoricalTemperatureChart` and `HistoricalPhChart`
- set Y axis domain to `[0, max]` for these charts

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cb112dd088328bad5a12d11132137