### PR TITLE
Subscribe to multiple STOMP topics

### DIFF
--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -12,7 +12,8 @@ import { trimOldEntries } from "../utils";
 import { useStomp } from '../hooks/useStomp';
 import styles from './SensorDashboard.module.css';
 
-const topic = "azadFarm/sensorData";
+const sensorTopic = "growSensors";
+const topics = [sensorTopic, "rootImages", "waterOutput", "waterTank"];
 
 const sensorFieldMap = {
     veml7700: ['lux'],
@@ -117,11 +118,11 @@ function SensorDashboard() {
         }
     }, [dailyData]);
 
-    useStomp(topic, setSensorData, setDailyData);
+    useStomp(topics, setSensorData, setDailyData);
 
     return (
         <div className={styles.dashboard}>
-            <Header topic={topic} />
+            <Header topic={sensorTopic} />
             <div className={styles.section}>
                 <h2 className={`${styles.sectionHeader} ${styles.liveHeader}`}>Live Data</h2>
                 <div className={styles.sectionBody}>


### PR DESCRIPTION
## Summary
- support multiple STOMP topics in `useStomp`
- subscribe to `growSensors`, `rootImages`, `waterOutput` and `waterTank`
- keep the dashboard header focused on the sensor data topic

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881259903ac8328a3e6a7600c27c2a8