### PR TITLE
Update charts with accessible color palette

### DIFF
--- a/src/colorPalette.js
+++ b/src/colorPalette.js
@@ -1,0 +1,7 @@
+export const palette = [
+  '#4E79A7', '#F28E2B', '#E15759', '#76B7B2',
+  '#59A14F', '#EDC949', '#AF7AA1', '#FF9DA7',
+  '#9C755F', '#BAB0AC'
+];
+export default palette;
+

--- a/src/components/HistoricalEcTdsChart.jsx
+++ b/src/components/HistoricalEcTdsChart.jsx
@@ -12,6 +12,7 @@ import {
     Legend,
     ResponsiveContainer,
 } from 'recharts';
+import palette from '../colorPalette';
 
 const HistoricalEcTdsChart = ({
     data,
@@ -95,7 +96,8 @@ const HistoricalEcTdsChart = ({
                         y2={tdsRange.max}
                         x1={start}
                         x2={end}
-                        fill="rgba(0,123,255,0.1)"
+                        fill={palette[0]}
+                        fillOpacity={0.1}
                         stroke="none"
                     />
                 )}
@@ -106,7 +108,8 @@ const HistoricalEcTdsChart = ({
                         y2={ecRange.max}
                         x1={start}
                         x2={end}
-                        fill="rgba(255,193,7,0.1)"
+                        fill={palette[5]}
+                        fillOpacity={0.1}
                         stroke="none"
                     />
                 )}
@@ -116,7 +119,7 @@ const HistoricalEcTdsChart = ({
                     yAxisId="left"
                     type="monotone"
                     dataKey="tds"
-                    stroke="#007bff"
+                    stroke={palette[0]}
                     dot={false}
                     isAnimationActive={false}
                 />
@@ -124,7 +127,7 @@ const HistoricalEcTdsChart = ({
                     yAxisId="right"
                     type="monotone"
                     dataKey="ec"
-                    stroke="#ffc107"
+                    stroke={palette[5]}
                     dot={false}
                     isAnimationActive={false}
                 />

--- a/src/components/HistoricalMultiBandChart.jsx
+++ b/src/components/HistoricalMultiBandChart.jsx
@@ -12,12 +12,9 @@ import {
     Label,
     ReferenceArea
 } from 'recharts';
+import palette from '../colorPalette';
 
-const colors = [
-    '#8884d8', '#82ca9d', '#ffc658', '#ff7300',
-    '#00C49F', '#FFBB28', '#FF8042', '#0088FE',
-    '#A28EDB', '#FF6666'
-];
+const colors = palette;
 
 const defaultBandKeys = [
     'F1', 'F2', 'F3', 'F4', 'F5', 'F6', 'F7', 'F8', 'clear', 'nir', 'lux'

--- a/src/components/HistoricalPhChart.jsx
+++ b/src/components/HistoricalPhChart.jsx
@@ -11,6 +11,7 @@ import {
     ReferenceArea,
     ResponsiveContainer,
 } from 'recharts';
+import palette from '../colorPalette';
 
 const HistoricalPhChart = ({
     data,
@@ -73,7 +74,8 @@ const HistoricalPhChart = ({
                         y2={phRange.max}
                         x1={start}
                         x2={end}
-                        fill="rgba(40,167,69,0.1)"
+                        fill={palette[4]}
+                        fillOpacity={0.1}
                         stroke="none"
                     />
                 )}
@@ -81,7 +83,7 @@ const HistoricalPhChart = ({
                 <Line
                     type="monotone"
                     dataKey="ph"
-                    stroke="#28a745"
+                    stroke={palette[4]}
                     dot={false}
                     isAnimationActive={false}
                 />

--- a/src/components/HistoricalTemperatureChart.jsx
+++ b/src/components/HistoricalTemperatureChart.jsx
@@ -11,6 +11,7 @@ import {
     ReferenceArea,
     ResponsiveContainer,
 } from 'recharts';
+import palette from '../colorPalette';
 
 const HistoricalTemperatureChart = ({
     data,
@@ -78,7 +79,8 @@ const HistoricalTemperatureChart = ({
                                 y2={tRange.max}
                                 x1={start}
                                 x2={end}
-                                fill="rgba(255,115,0,0.1)"
+                                fill={palette[1]}
+                                fillOpacity={0.1}
                                 stroke="none"
                             />
                         )}
@@ -88,7 +90,8 @@ const HistoricalTemperatureChart = ({
                                 y2={hRange.max}
                                 x1={start}
                                 x2={end}
-                                fill="rgba(136,132,216,0.1)"
+                                fill={palette[0]}
+                                fillOpacity={0.1}
                                 stroke="none"
                             />
                         )}
@@ -99,14 +102,14 @@ const HistoricalTemperatureChart = ({
             <Line
                 type="monotone"
                 dataKey="temperature"
-                stroke="#ff7300"
+                stroke={palette[1]}
                 dot={false}
                 isAnimationActive={false}
             />
             <Line
                 type="monotone"
                 dataKey="humidity"
-                stroke="#8884d8"
+                stroke={palette[0]}
                 dot={false}
                 isAnimationActive={false}
             />

--- a/src/components/SpectrumBarChart.jsx
+++ b/src/components/SpectrumBarChart.jsx
@@ -1,9 +1,10 @@
 import React, { useMemo } from 'react';
 import {
     BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
-    Label, ReferenceArea
+    Label, ReferenceArea, Cell
 } from 'recharts';
 import idealRanges from '../idealRangeConfig';
+import palette from '../colorPalette';
 
 const bandMeta = [
     ['F1', '415 nm (F1)'],
@@ -77,13 +78,18 @@ function SpectrumBarChart({ sensorData }) {
                             x2={d.index + 0.5}
                             y1={d.min}
                             y2={d.max}
-                            fill="rgba(0, 0, 255, 0.1)"
+                            fill={palette[d.index % palette.length]}
+                            fillOpacity={0.1}
                             stroke="none"
                         />
                     )
                 ))}
                 <Tooltip />
-                <Bar dataKey="value" fill="#82ca9d" isAnimationActive={false} animationDuration={0} />
+                <Bar dataKey="value" isAnimationActive={false} animationDuration={0}>
+                    {data.map((d, idx) => (
+                        <Cell key={`cell-${idx}`} fill={palette[idx % palette.length]} />
+                    ))}
+                </Bar>
             </BarChart>
         </ResponsiveContainer>
     );


### PR DESCRIPTION
## Summary
- centralize chart colors in `colorPalette.js`
- use new palette in `HistoricalMultiBandChart`
- update temperature, pH, EC/TDS, and spectrum bar charts to use palette
- match `ReferenceArea` fill colors to corresponding lines

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68835cc7eebc8328969f242170fb019c