### PR TITLE
Adjust history section colors

### DIFF
--- a/src/components/SensorDashboard.module.css
+++ b/src/components/SensorDashboard.module.css
@@ -51,12 +51,12 @@
     border: 1px solid #ccc;
     padding: 10px;
     margin-bottom: 20px;
-    background-color: #eef6ff;
+    background-color: #f7f7f7;
 }
 .historyLegend {
     font-weight: bold;
     padding: 0 5px;
-    background-color: #eef6ff;
+    background-color: #f7f7f7;
 }
 .filterLabel {
     margin-left: 10px;


### PR DESCRIPTION
## Summary
- tweak background colors for historical charts controls & legend

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68835cc9f09883289ed190b549527af0