### PR TITLE
Fix timezone for history date inputs

### DIFF
--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -12,6 +12,12 @@ import { transformAggregatedData } from "../utils";
 import { useStomp } from '../hooks/useStomp';
 import styles from './SensorDashboard.module.css';
 
+function toLocalInputValue(date) {
+    const tz = date.getTimezoneOffset() * 60000;
+    const local = new Date(date.getTime() - tz);
+    return local.toISOString().slice(0, 16);
+}
+
 const sensorTopic = "growSensors";
 const topics = [sensorTopic, "rootImages", "waterOutput", "waterTank"];
 
@@ -36,8 +42,8 @@ function SensorDashboard() {
         health: { veml7700: false, as7341: false, sht3x: false, tds: false, ph: false },
     });
     const now = Date.now();
-    const defaultFrom = new Date(now - 6 * 60 * 60 * 1000).toISOString().slice(0,16);
-    const defaultTo = new Date(now).toISOString().slice(0,16);
+    const defaultFrom = toLocalInputValue(new Date(now - 6 * 60 * 60 * 1000));
+    const defaultTo = toLocalInputValue(new Date(now));
     const [fromDate, setFromDate] = useState(defaultFrom);
     const [toDate, setToDate] = useState(defaultTo);
     const [rangeData, setRangeData] = useState([]);
@@ -146,7 +152,7 @@ function SensorDashboard() {
                                 To:
                                 <input type="datetime-local" value={toDate} onChange={e => setToDate(e.target.value)} />
                             </label>
-                            <button type="button" className={styles.nowButton} onClick={() => setToDate(new Date().toISOString().slice(0,16))}>Now</button>
+                            <button type="button" className={styles.nowButton} onClick={() => setToDate(toLocalInputValue(new Date()))}>Now</button>
                             <button type="button" className={styles.applyButton} onClick={fetchReportData}>Apply</button>
                         </div>
                         <div className={styles.rangeLabel}>


### PR DESCRIPTION
## Summary
- adjust default range calculation and "Now" button to use local timezone

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68836db6b6188328a74818847de8c310