### PR TITLE
Add auto refresh for historical charts

### DIFF
--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -60,6 +60,9 @@ function SensorDashboard() {
     const [startTime, setStartTime] = useState(xDomain[0]);
     const [endTime, setEndTime] = useState(xDomain[1]);
 
+    const [autoRefresh, setAutoRefresh] = useState(false);
+    const [refreshInterval, setRefreshInterval] = useState(60 * 1000);
+
     const fetchReportData = useCallback(async () => {
         if (!fromDate || !toDate) return;
         const fromIso = new Date(fromDate).toISOString();
@@ -100,6 +103,47 @@ function SensorDashboard() {
         }
     }, [fromDate, toDate]);
 
+    const fetchNewData = useCallback(async () => {
+        const fromIso = new Date(endTime).toISOString();
+        const nowDate = new Date();
+        const toIso = nowDate.toISOString();
+        const url = `https://api.hydroleaf.se/api/sensors/history/aggregated?espId=esp32-01&from=${fromIso}&to=${toIso}`;
+        try {
+            const res = await fetch(url);
+            if (!res.ok) throw new Error('bad response');
+            const json = await res.json();
+            const entries = transformAggregatedData(json);
+            const processed = entries.map(d => ({
+                time: d.timestamp,
+                ...d,
+                lux: d.lux?.value ?? 0,
+            })).filter(d => d.time > endTime);
+            if (processed.length) {
+                setRangeData(prev => [...prev, ...processed]);
+                setTempRangeData(prev => [...prev, ...processed.map(d => ({
+                    time: d.time,
+                    temperature: d.temperature?.value ?? 0,
+                    humidity: d.humidity?.value ?? 0,
+                }))]);
+                setPhRangeData(prev => [...prev, ...processed.map(d => ({
+                    time: d.time,
+                    ph: d.ph?.value ?? 0,
+                }))]);
+                setEcTdsRangeData(prev => [...prev, ...processed.map(d => ({
+                    time: d.time,
+                    ec: d.ec?.value ?? 0,
+                    tds: d.tds?.value ?? 0,
+                }))]);
+            }
+            const newEnd = nowDate.getTime();
+            setToDate(toLocalInputValue(nowDate));
+            setXDomain([startTime, newEnd]);
+            setEndTime(newEnd);
+        } catch (e) {
+            console.error('Failed to fetch history', e);
+        }
+    }, [endTime, startTime]);
+
     const formatTime = (t) => {
         const d = new Date(t);
         return (
@@ -114,6 +158,13 @@ function SensorDashboard() {
     useEffect(() => {
         fetchReportData();
     }, []);
+
+    useEffect(() => {
+        if (!autoRefresh) return;
+        fetchNewData();
+        const id = setInterval(fetchNewData, refreshInterval);
+        return () => clearInterval(id);
+    }, [autoRefresh, refreshInterval, fetchNewData]);
 
     useStomp(topics, setSensorData, () => {});
 
@@ -160,6 +211,28 @@ function SensorDashboard() {
                             </label>
                             <button type="button" className={styles.nowButton} onClick={() => setToDate(toLocalInputValue(new Date()))}>Now</button>
                             <button type="button" className={styles.applyButton} onClick={fetchReportData}>Apply</button>
+                        </div>
+                        <div className={styles.filterRow}>
+                            <label className={styles.filterLabel}>
+                                <input
+                                    type="checkbox"
+                                    checked={autoRefresh}
+                                    onChange={e => setAutoRefresh(e.target.checked)}
+                                />
+                                {' '}Auto Refresh
+                            </label>
+                            <select
+                                className={styles.intervalSelect}
+                                value={refreshInterval}
+                                onChange={e => setRefreshInterval(Number(e.target.value))}
+                                disabled={!autoRefresh}
+                            >
+                                <option value={60000}>1min</option>
+                                <option value={300000}>5min</option>
+                                <option value={600000}>10min</option>
+                                <option value={1800000}>30min</option>
+                                <option value={3600000}>1h</option>
+                            </select>
                         </div>
                         <div className={styles.rangeLabel}>
                             {`From: ${formatTime(startTime)} until: ${formatTime(endTime)}`}

--- a/src/components/SensorDashboard.module.css
+++ b/src/components/SensorDashboard.module.css
@@ -72,6 +72,10 @@
     margin-left: 10px;
 }
 
+.intervalSelect {
+    margin-left: 10px;
+}
+
 .fieldSpacer {
     margin: 0 10px;
     font-weight: bold;


### PR DESCRIPTION
## Summary
- allow automatic refresh in the Historical Range section
- add dropdown to select refresh interval

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688371feee9c8328b96d7e60bac32e16