### PR TITLE
Add auto refresh for historical charts

### DIFF
--- a/src/components/SensorDashboard.module.css
+++ b/src/components/SensorDashboard.module.css
@@ -72,6 +72,10 @@
     margin-left: 10px;
 }
 
+.intervalSelect {
+    margin-left: 10px;
+}
+
 .fieldSpacer {
     margin: 0 10px;
     font-weight: bold;


### PR DESCRIPTION
## Summary
- allow automatic refresh in the Historical Range section
- add dropdown to select refresh interval
- fix flicker by storing latest time ranges in refs

## Testing
- `npm run lint` *(fails: Cannot find package 'globals')*
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688371feee9c8328b96d7e60bac32e16