### PR TITLE
Add accurate colors for spectral bands

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,17 @@ You can inspect past readings by selecting one of the preset periods in the
 1 month. Selecting a period freezes the window so it does not keep advancing as
 new readings arrive. The start and end timestamps of the chosen range are shown
 below the dropdown.
+### Spectral Bands
+
+| Band | Center (nm) | Range (nm) | Color |
+|------|-------------|------------|-------|
+| F1   | 415         | 400–430   | بنفش (Violet) |
+| F2   | 445         | 430–460   | آبی (Blue) |
+| F3   | 480         | 460–500   | فیروزه‌ای (Cyan) |
+| F4   | 515         | 500–530   | سبز (Green) |
+| F5   | 555         | 530–570   | سبز – زرد (Green/Yellow) |
+| F6   | 590         | 570–610   | زرد – نارنجی (Yellow/Orange) |
+| F7   | 630         | 610–650   | نارنجی – قرمز (Orange/Red) |
+| F8   | 680         | 650–700   | قرمز (Red) |
+| Clear| -           | طیف کامل نور مرئی | همه‌رنگ‌ها |
+| NIR  | -           | >700       | مادون قرمز نزدیک |

--- a/src/components/HistoricalMultiBandChart.jsx
+++ b/src/components/HistoricalMultiBandChart.jsx
@@ -12,9 +12,7 @@ import {
     Label,
     ReferenceArea
 } from 'recharts';
-import palette from '../colorPalette';
-
-const colors = palette;
+import spectralColors from '../spectralColors';
 
 const defaultBandKeys = [
     'F1', 'F2', 'F3', 'F4', 'F5', 'F6', 'F7', 'F8', 'clear', 'nir', 'lux'
@@ -114,7 +112,7 @@ const HistoricalMultiBandChart = ({
                                 y2={range.max}
                                 x1={start}
                                 x2={end}
-                                fill={colors[idx % colors.length]}
+                                fill={spectralColors[key]}
                                 fillOpacity={0.1}
                                 stroke="none"
                             />
@@ -128,7 +126,7 @@ const HistoricalMultiBandChart = ({
                         key={key}
                         type="monotone"
                         dataKey={key}
-                        stroke={colors[idx % colors.length]}
+                        stroke={spectralColors[key]}
                         dot={({ payload }) =>
                             payload[`${key}Out`] ? <circle r={3} fill="red" /> : null
                         }

--- a/src/components/SpectrumBarChart.jsx
+++ b/src/components/SpectrumBarChart.jsx
@@ -5,6 +5,7 @@ import {
 } from 'recharts';
 import idealRanges from '../idealRangeConfig';
 import palette from '../colorPalette';
+import spectralColors from '../spectralColors';
 
 const bandMeta = [
     ['F1', '415 nm (F1)'],
@@ -37,6 +38,7 @@ function SpectrumBarChart({ sensorData }) {
                 const rangeKey = bandMap[key] || key;
                 const range = idealRanges[rangeKey]?.idealRange;
                 return {
+                    key,
                     index,
                     name: label,
                     value: sensorData[key] || 0,
@@ -78,7 +80,7 @@ function SpectrumBarChart({ sensorData }) {
                             x2={d.index + 0.5}
                             y1={d.min}
                             y2={d.max}
-                            fill={palette[d.index % palette.length]}
+                            fill={spectralColors[d.key] || palette[d.index % palette.length]}
                             fillOpacity={0.1}
                             stroke="none"
                         />
@@ -87,7 +89,7 @@ function SpectrumBarChart({ sensorData }) {
                 <Tooltip />
                 <Bar dataKey="value" isAnimationActive={false} animationDuration={0}>
                     {data.map((d, idx) => (
-                        <Cell key={`cell-${idx}`} fill={palette[idx % palette.length]} />
+                        <Cell key={`cell-${idx}`} fill={spectralColors[d.key] || palette[idx % palette.length]} />
                     ))}
                 </Bar>
             </BarChart>

--- a/src/idealRangeConfig.js
+++ b/src/idealRangeConfig.js
@@ -25,43 +25,63 @@ const idealRangeConfig = {
     },
     '415nm': {
         idealRange: { min: 2, max: 50 },
-        description: 'Supports early cell growth.'
+        description: 'Supports early cell growth.',
+        spectralRange: '400\u2013430 nm',
+        color: '\u0628\u0646\u0641\u0634'
     },
     '445nm': {
         idealRange: { min: 80, max: 200 },
-        description: 'Key for chlorophyll and leafy growth.'
+        description: 'Key for chlorophyll and leafy growth.',
+        spectralRange: '430\u2013460 nm',
+        color: '\u0622\u0628\u06cc'
     },
     '480nm': {
         idealRange: { min: 70, max: 180 },
-        description: 'Blue-green light; supports vegetative growth and pigment production.'
+        description: 'Blue-green light; supports vegetative growth and pigment production.',
+        spectralRange: '460\u2013500 nm',
+        color: '\u0641\u06cc\u0631\u0648\u0632\u0647\u200c\u0627\u06cc'
     },
     '515nm': {
         idealRange: { min: 40, max: 150 },
-        description: 'Green light; penetrates deeper into leaves and regulates growth balance.'
+        description: 'Green light; penetrates deeper into leaves and regulates growth balance.',
+        spectralRange: '500\u2013530 nm',
+        color: '\u0633\u0628\u0632'
     },
     '555nm': {
         idealRange: { min: 80, max: 200 },
-        description: 'Mid-green light; complements blue and red for fuller spectrum balance.'
+        description: 'Mid-green light; complements blue and red for fuller spectrum balance.',
+        spectralRange: '530\u2013570 nm',
+        color: '\u0633\u0628\u0632 \u2013 \u0632\u0631\u062f'
     },
     '590nm': {
         idealRange: { min: 50, max: 140 },
-        description: 'Yellow light; minor effect on photosynthesis but supports photomorphogenesis.'
+        description: 'Yellow light; minor effect on photosynthesis but supports photomorphogenesis.',
+        spectralRange: '570\u2013610 nm',
+        color: '\u0632\u0631\u062f \u2013 \u0646\u0627\u0631\u0646\u062c\u06cc'
     },
     '630nm': {
         idealRange: { min: 120, max: 300 },
-        description: 'Helps in flowering and general development.'
+        description: 'Helps in flowering and general development.',
+        spectralRange: '610\u2013650 nm',
+        color: '\u0646\u0627\u0631\u0646\u062c\u06cc \u2013 \u0642\u0631\u0645\u0632'
     },
     '680nm': {
         idealRange: { min: 130, max: 320 },
-        description: 'Peak light absorption for photosynthesis.'
+        description: 'Peak light absorption for photosynthesis.',
+        spectralRange: '650\u2013700 nm',
+        color: '\u0642\u0631\u0645\u0632'
     },
     clear: {
         idealRange: { min: 300, max: 900 },
-        description: 'Total visible light intensity. General index of light.'
+        description: 'Total visible light intensity. General index of light.',
+        spectralRange: '\u0637\u06cc\u0641 \u06a9\u0627\u0645\u0644 \u0646\u0648\u0631 \u0645\u0631\u0626\u06cc',
+        color: '\u0647\u0645\u0647\u200c\u0631\u0646\u06af\u200c\u0647\u0627'
     },
     nir: {
         idealRange: { min: 20, max: 100 },
-        description: 'Higher NIR may indicate heat. Keep it low indoors.'
+        description: 'Higher NIR may indicate heat. Keep it low indoors.',
+        spectralRange: '>700 nm',
+        color: '\u0645\u0627\u062f\u0648\u0646 \u0642\u0631\u0645\u0632 \u0646\u0632\u062f\u06cc\u06a9'
     }
 };
 

--- a/src/spectralColors.js
+++ b/src/spectralColors.js
@@ -1,0 +1,15 @@
+export const spectralColors = {
+  F1: '#8a2be2', // violet
+  F2: '#1e90ff', // blue
+  F3: '#00ffff', // cyan
+  F4: '#32cd32', // green
+  F5: '#9acd32', // yellow-green
+  F6: '#ffa500', // orange
+  F7: '#ff4500', // orange-red
+  F8: '#ff0000', // red
+  clear: '#888888', // grey
+  nir: '#800000', // near infrared (dark red)
+  lux: '#ffd700', // gold
+};
+
+export default spectralColors;


### PR DESCRIPTION
## Summary
- map each spectral band to a specific hex color
- color spectrum bar chart and historical chart with these band colors
- keep axis labels simple

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68837ae8e4ec8328a4711ba188434b87