### PR TITLE
Adjust spectrum chart width

### DIFF
--- a/src/components/SensorDashboard.module.css
+++ b/src/components/SensorDashboard.module.css
@@ -144,7 +144,7 @@
         margin: 0;
     }
     .spectrumBarChartWrapper {
-        width: 50%;
+        width: 80%;
         margin: 0 auto;
     }
 }


### PR DESCRIPTION
## Summary
- make the live spectrum bar chart take up 80% width on larger screens

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68849c0430d083288118656267ecb679