### PR TITLE
Fix tab highlight style

### DIFF
--- a/src/components/SensorDashboard.module.css
+++ b/src/components/SensorDashboard.module.css
@@ -41,6 +41,23 @@
     gap: 10px;
 }
 
+.tabBar {
+    text-align: center;
+    margin: 10px 0 20px;
+}
+
+.tab {
+    padding: 6px 12px;
+    margin: 0 4px;
+    border: 1px solid #ccc;
+    background: #eee;
+    cursor: pointer;
+}
+
+.activeTab {
+    background: #c8e6c9;
+}
+
 .noteBlock {
     margin-top: 20px;
     font-size: 0.8em;


### PR DESCRIPTION
## Summary
- restore `tabBar`, `tab`, and `activeTab` CSS classes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: internet disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68864a172a8c8328811ebbcb924024f7