### PR TITLE
Fix STOMP host header

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ VITE_MQTT_USERNAME=
 VITE_MQTT_PASSWORD=
 ```
 
+Additionally, set `VITE_WS_URL` to the WebSocket endpoint that provides the live
+STOMP feed. If not defined, it defaults to `wss://api.hydroleaf.se/ws`.
+
 These variables are used to establish the MQTT connection.
 Make sure the file is named `.env` and each variable starts with the `VITE_` prefix so that Vite exposes them to the frontend.
 

--- a/src/hooks/useStomp.js
+++ b/src/hooks/useStomp.js
@@ -10,6 +10,7 @@ export function useStomp(topics, setSensorData, setDailyData) {
         if (location.protocol === 'https:' && wsUrl.startsWith('ws://')) {
             wsUrl = 'wss://' + wsUrl.slice(5);
         }
+        const wsHost = new URL(wsUrl).hostname;
 
         let socket;
         let buffer = '';
@@ -90,7 +91,7 @@ export function useStomp(topics, setSensorData, setDailyData) {
             socket.send(
                 buildFrame('CONNECT', {
                     'accept-version': '1.2',
-                    host: location.hostname,
+                    host: wsHost,
                     'heart-beat': '0,0'
                 })
             );


### PR DESCRIPTION
## Summary
- derive host header from the WebSocket URL
- document `VITE_WS_URL` environment variable

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68864e85a3b88328bbac8a419b127440