### PR TITLE
Fix sensor health key normalization

### DIFF
--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -42,7 +42,7 @@ function SensorDashboard() {
         tds: { value: 0, unit: "ppm" },
         ec: { value: 0, unit: "mS/cm" },
         ph: { value: 0, unit: '' },
-        health: { veml7700: false, as7341: false, sht3x: false, tds: false, ph: false },
+        health: {},
     });
     const [activeTopic, setActiveTopic] = useState(sensorTopic);
     const [deviceData, setDeviceData] = useState({});

--- a/src/utils.js
+++ b/src/utils.js
@@ -125,7 +125,9 @@ export function normalizeSensorData(data) {
             result.health = {};
             for (const key in data.health) {
                 const val = data.health[key];
-                result.health[key] = val === true || val === 'true' || val === 1;
+                const base = key.split('-')[0];
+                result.health[base] =
+                    val === true || val === 'true' || val === 1;
             }
         }
     }


### PR DESCRIPTION
## Summary
- map health entries with IDs like `sht3x-01` to base sensor names
- render sensor cards using normalized health names

## Testing
- `npm test` *(fails: `vitest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6886517ffba88328a3ba7f5d4b700edc