### PR TITLE
Fix sensor cards not showing without health info

### DIFF
--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -42,7 +42,7 @@ function SensorDashboard() {
         tds: { value: 0, unit: "ppm" },
         ec: { value: 0, unit: "mS/cm" },
         ph: { value: 0, unit: '' },
-        health: { veml7700: false, as7341: false, sht3x: false, tds: false, ph: false },
+        health: {},
     });
     const [activeTopic, setActiveTopic] = useState(sensorTopic);
     const [deviceData, setDeviceData] = useState({});
@@ -226,11 +226,14 @@ function SensorDashboard() {
                 <div className={styles.sectionBody}>
                     {activeTopic === sensorTopic && (
                         <div className={styles.sensorGrid}>
-                            {Object.entries(sensorData.health).map(([name, ok]) => (
+                            {(Object.keys(sensorData.health).length
+                                ? Object.keys(sensorData.health)
+                                : Object.keys(sensorFieldMap)
+                            ).map(name => (
                                 <SensorCard
                                     key={name}
                                     name={name}
-                                    ok={ok}
+                                    ok={sensorData.health[name] ?? false}
                                     fields={sensorFieldMap[name] || []}
                                     sensorData={sensorData}
                                 />

--- a/src/utils.js
+++ b/src/utils.js
@@ -98,7 +98,12 @@ export function normalizeSensorData(data) {
                 break;
         }
     }
-        result.health = { ...data.health };
+        result.health = {};
+        for (const key in data.health) {
+            const val = data.health[key];
+            const base = key.split('-')[0];
+            result.health[base] = val === true || val === 'true' || val === 1;
+        }
     } else {
         if ('temperature' in data)
             result.temperature = { value: Number(data.temperature), unit: '°C' };
@@ -125,7 +130,9 @@ export function normalizeSensorData(data) {
             result.health = {};
             for (const key in data.health) {
                 const val = data.health[key];
-                result.health[key] = val === true || val === 'true' || val === 1;
+                const base = key.split('-')[0];
+                result.health[base] =
+                    val === true || val === 'true' || val === 1;
             }
         }
     }


### PR DESCRIPTION
## Summary
- show all known sensor cards even when no health data has been received

## Testing
- `npm test` *(fails: `vitest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6886517ffba88328a3ba7f5d4b700edc