### PR TITLE
Add console logs for incoming sensor data

### DIFF
--- a/src/components/SensorCard.jsx
+++ b/src/components/SensorCard.jsx
@@ -24,6 +24,11 @@ function getRowColor(value, range) {
 }
 
 function SensorCard({ name, ok, fields = [], sensorData }) {
+    const cardData = {};
+    for (const f of fields) {
+        cardData[f] = sensorData[f];
+    }
+    console.log('🖼️ Rendering SensorCard for', name, cardData);
     const descriptions = [];
 
     const rows = fields.map(field => {

--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -44,6 +44,9 @@ function SensorDashboard() {
         ph: { value: 0, unit: '' },
         health: {},
     });
+    useEffect(() => {
+        console.log('📊 sensorData state changed:', sensorData);
+    }, [sensorData]);
     const [activeTopic, setActiveTopic] = useState(sensorTopic);
     const [deviceData, setDeviceData] = useState({});
     const toLocalInputValue = (ts) => {
@@ -160,6 +163,7 @@ function SensorDashboard() {
     }, []);
 
     const handleStompMessage = useCallback((topic, msg) => {
+        console.log('📨 handleStompMessage topic:', topic, 'msg:', msg);
         let payload = msg;
         if (msg && typeof msg === 'object' && 'payload' in msg) {
             payload =
@@ -171,14 +175,20 @@ function SensorDashboard() {
         let data = payload;
         if (topic === sensorTopic) {
             const norm = normalizeSensorData(payload);
+            console.log('🔄 normalized sensor message:', norm);
             const cleaned = filterNoise(norm);
-            if (!cleaned) return;
+            if (!cleaned) {
+                console.log('🛑 message filtered out as noise', norm);
+                return;
+            }
             data = cleaned;
+            console.log('💾 updating sensorData state with:', data);
             setSensorData(data);
         }
         setDeviceData(prev => {
             const t = { ...(prev[topic] || {}) };
             t[deviceId] = data;
+            console.log('📥 setDeviceData for', topic, deviceId, data);
             return { ...prev, [topic]: t };
         });
     }, []);

--- a/src/hooks/useStomp.js
+++ b/src/hooks/useStomp.js
@@ -23,8 +23,7 @@ export function useStomp(topics, onMessage) {
         };
 
         const handleFrame = (frame) => {
-            console.log("Raw STOMP frame received:", frame);
-            console.log("frame.command:", frame.command);
+            console.log("🟡 handleFrame ->", frame.command, frame.headers);
             if (frame.command === 'CONNECTED') {
                 topicList.forEach((t, idx) => {
                     const dest = `/topic/${t}`;
@@ -50,6 +49,7 @@ export function useStomp(topics, onMessage) {
                 try {
                     const parsed = parseSensorJson(frame.body);
                     console.log("✅ Parsed payload:", parsed);
+                    console.log('🔰 Dispatching message to callback', topic, parsed);
                     onMessage(topic, parsed);
                 } catch (e) {
                     console.error('❌ Invalid STOMP message', e);
@@ -97,7 +97,7 @@ export function useStomp(topics, onMessage) {
         });
 
         socket.addEventListener('message', (event) => {
-            console.log('Received message', event.data);
+            console.log('🟣 WS message event:', event.data);
             processData(event.data);
         });
 


### PR DESCRIPTION
## Summary
- track WebSocket messages in `useStomp`
- log parsed sensor data in `SensorDashboard`
- log props when `SensorCard` renders

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6887440d3b488328a94fae5e2b9de9a3