### PR TITLE
Fix sensor list always visible

### DIFF
--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -236,9 +236,11 @@ function SensorDashboard() {
                 <div className={styles.sectionBody}>
                     {activeTopic === sensorTopic && (
                         <div className={styles.sensorGrid}>
-                            {(Object.keys(sensorData.health).length
-                                ? Object.keys(sensorData.health)
-                                : Object.keys(sensorFieldMap)
+                            {Array.from(
+                                new Set([
+                                    ...Object.keys(sensorFieldMap),
+                                    ...Object.keys(sensorData.health),
+                                ])
                             ).map(name => (
                                 <SensorCard
                                     key={name}


### PR DESCRIPTION
## Summary
- show sensor cards even if no health entry exists so that DeviceCard remains visible when health is false or missing

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68876de3fbb883288a8785d3a4ab096e