### PR TITLE
Add DeviceTable for live device overview

### DIFF
--- a/src/components/DeviceTable.jsx
+++ b/src/components/DeviceTable.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import styles from './DeviceTable.module.css';
+
+function DeviceTable({ devices = {} }) {
+    const entries = Object.entries(devices);
+    if (entries.length === 0) {
+        return null;
+    }
+    const fieldSet = new Set();
+    for (const [, data] of entries) {
+        for (const key of Object.keys(data)) {
+            if (key === 'health') continue;
+            fieldSet.add(key);
+        }
+    }
+    const fields = Array.from(fieldSet);
+
+    return (
+        <div className={styles.wrapper}>
+            <table className={styles.table}>
+                <thead>
+                    <tr>
+                        <th>Device ID</th>
+                        {fields.map(f => (
+                            <th key={f}>{f}</th>
+                        ))}
+                    </tr>
+                </thead>
+                <tbody>
+                    {entries.map(([id, data]) => (
+                        <tr key={id}>
+                            <td>{id}</td>
+                            {fields.map(field => {
+                                const valObj = data[field];
+                                const value =
+                                    valObj && typeof valObj === 'object' && 'value' in valObj
+                                        ? valObj.value
+                                        : valObj;
+                                const display =
+                                    value === undefined || value === null
+                                        ? '-'
+                                        : typeof value === 'number'
+                                        ? value.toFixed(1)
+                                        : value;
+                                const unit =
+                                    valObj && typeof valObj === 'object' && valObj.unit
+                                        ? ` ${valObj.unit}`
+                                        : '';
+                                return <td key={field}>{display}{unit}</td>;
+                            })}
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+}
+
+export default DeviceTable;

--- a/src/components/DeviceTable.module.css
+++ b/src/components/DeviceTable.module.css
@@ -1,0 +1,15 @@
+.wrapper {
+    overflow-x: auto;
+}
+
+.table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.table th,
+.table td {
+    border: 1px solid #ddd;
+    padding: 4px;
+    text-align: center;
+}

--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -7,7 +7,7 @@ import HistoricalClearLuxChart from "./HistoricalClearLuxChart";
 import HistoricalPhChart from "./HistoricalPhChart";
 import HistoricalEcTdsChart from "./HistoricalEcTdsChart";
 import Header from "./Header";
-import DeviceCard from "./DeviceCard";
+import DeviceTable from "./DeviceTable";
 import SensorCard from "./SensorCard";
 import { transformAggregatedData, normalizeSensorData, filterNoise } from "../utils";
 import idealRangeConfig from "../idealRangeConfig";
@@ -253,11 +253,7 @@ function SensorDashboard() {
                         </div>
                     )}
 
-                    <div className={styles.sensorGrid}>
-                        {Object.entries(deviceData[activeTopic] || {}).map(([id, data]) => (
-                            <DeviceCard key={id} deviceId={id} data={data} />
-                        ))}
-                    </div>
+                    <DeviceTable devices={deviceData[activeTopic] || {}} />
 
                     {activeTopic === sensorTopic && (
                         <div className={styles.spectrumBarChartWrapper}>


### PR DESCRIPTION
## Summary
- add `DeviceTable` component to list devices in a single table
- display `DeviceTable` in `SensorDashboard` in place of multiple `DeviceCard`s

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68876f5626d88328b67b1edfa7f395ad