### PR TITLE
Add sensor health indicators to DeviceTable

### DIFF
--- a/src/components/DeviceTable.jsx
+++ b/src/components/DeviceTable.jsx
@@ -20,16 +20,28 @@ function DeviceTable({ devices = {} }) {
             <table className={styles.table}>
                 <thead>
                     <tr>
-                        <th>Device ID</th>
+                        <th>
+                            <div className={styles.cellTop}>Device ID</div>
+                            <div className={styles.divider}></div>
+                            <div className={styles.cellBottom}>Status</div>
+                        </th>
                         {fields.map(f => (
-                            <th key={f}>{f}</th>
+                            <th key={f}>
+                                <div className={styles.cellTop}>{f}</div>
+                                <div className={styles.divider}></div>
+                                <div className={styles.cellBottom}>Value</div>
+                            </th>
                         ))}
                     </tr>
                 </thead>
                 <tbody>
                     {entries.map(([id, data]) => (
                         <tr key={id}>
-                            <td>{id}</td>
+                            <td>
+                                <div className={styles.cellTop}>{id}</div>
+                                <div className={styles.divider}></div>
+                                <div className={styles.cellBottom}>status</div>
+                            </td>
                             {fields.map(field => {
                                 const valObj = data[field];
                                 const value =
@@ -46,7 +58,23 @@ function DeviceTable({ devices = {} }) {
                                     valObj && typeof valObj === 'object' && valObj.unit
                                         ? ` ${valObj.unit}`
                                         : '';
-                                return <td key={field}>{display}{unit}</td>;
+                                const ok = data.health?.[field] ?? false;
+                                return (
+                                    <td key={field}>
+                                        <div className={styles.cellTop}>
+                                            <span
+                                                className={`${styles.indicator} ${
+                                                    ok ? styles.on : styles.off
+                                                }`}
+                                            ></span>
+                                        </div>
+                                        <div className={styles.divider}></div>
+                                        <div className={styles.cellBottom}>
+                                            {display}
+                                            {unit}
+                                        </div>
+                                    </td>
+                                );
                             })}
                         </tr>
                     ))}

--- a/src/components/DeviceTable.module.css
+++ b/src/components/DeviceTable.module.css
@@ -13,3 +13,29 @@
     padding: 4px;
     text-align: center;
 }
+
+.cellTop,
+.cellBottom {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.divider {
+    border-top: 1px solid #ddd;
+    margin: 2px 0;
+}
+
+.indicator {
+    border-radius: 50%;
+    width: 12px;
+    height: 12px;
+}
+
+.on {
+    background-color: green;
+}
+
+.off {
+    background-color: red;
+}


### PR DESCRIPTION
## Summary
- show header split layout and status indicators in `DeviceTable`
- add styling for circle indicators

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688771f189908328944c374356672849