### PR TITLE
Update indicator layout

### DIFF
--- a/src/components/DeviceTable.jsx
+++ b/src/components/DeviceTable.jsx
@@ -65,12 +65,12 @@ function DeviceTable({ devices = {} }) {
                             <td>{r.range?.max ?? '-'}</td>
                             {r.cells.map((c, i) => (
                                 <td key={deviceIds[i]}>
-                                    <div className={styles.cellTop}>
+                                    <div className={styles.cellWrapper}>
                                         <span
                                             className={`${styles.indicator} ${c.ok ? styles.on : styles.off}`}
                                         ></span>
+                                        <span className={styles.cellValue}>{c.value ?? '-'}</span>
                                     </div>
-                                    <div className={styles.cellBottom}>{c.value ?? '-'}</div>
                                 </td>
                             ))}
                         </tr>

--- a/src/components/DeviceTable.module.css
+++ b/src/components/DeviceTable.module.css
@@ -14,11 +14,16 @@
     text-align: center;
 }
 
-.cellTop,
-.cellBottom {
+
+.cellWrapper {
     display: flex;
     align-items: center;
     justify-content: center;
+    gap: 4px;
+}
+
+.cellValue {
+    display: inline-block;
 }
 
 


### PR DESCRIPTION
## Summary
- position the health indicator next to the value in `DeviceTable`
- adjust CSS for new indicator layout

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68879a20f6cc83288b49e07333321a37