### PR TITLE
Render DeviceTable immediately

### DIFF
--- a/src/components/DeviceTable.jsx
+++ b/src/components/DeviceTable.jsx
@@ -71,7 +71,6 @@ sensorModelMap.nir = 'AS7341';
 
 function DeviceTable({ devices = {} }) {
     const deviceIds = Object.keys(devices);
-    if (deviceIds.length === 0) return null;
 
     const reverseBandMap = Object.fromEntries(
         Object.entries(bandMap).map(([k, v]) => [v, k])


### PR DESCRIPTION
## Summary
- ensure DeviceTable mounts even when no data is present

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887be713280832886ba136a71a97c23