### PR TITLE
Render DeviceTable immediately

### DIFF
--- a/src/components/DeviceTable.jsx
+++ b/src/components/DeviceTable.jsx
@@ -71,7 +71,6 @@ sensorModelMap.nir = 'AS7341';
 
 function DeviceTable({ devices = {} }) {
     const deviceIds = Object.keys(devices);
-    if (deviceIds.length === 0) return null;
 
     const reverseBandMap = Object.fromEntries(
         Object.entries(bandMap).map(([k, v]) => [v, k])

--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -234,7 +234,12 @@ function SensorDashboard() {
                 <h2 className={`${styles.sectionHeader} ${styles.liveHeader}`}>Live Data</h2>
                 <div className={styles.sectionBody}>
 
-                    <DeviceTable devices={deviceData[activeTopic] || {}} />
+                    <DeviceTable
+                        devices={
+                            deviceData[activeTopic] ||
+                            (activeTopic === sensorTopic ? { placeholder: sensorData } : {})
+                        }
+                    />
 
                     {activeTopic === sensorTopic && (
                         <div className={styles.spectrumBarChartWrapper}>


### PR DESCRIPTION
## Summary
- ensure DeviceTable mounts even when no data is present
- fall back to placeholder data so the table is visible with zero values

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887be713280832886ba136a71a97c23