### PR TITLE
Add header update for active topic

### DIFF
--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -218,7 +218,7 @@ function SensorDashboard() {
 
     return (
         <div className={styles.dashboard}>
-            <Header topic={sensorTopic} />
+            <Header topic={activeTopic} />
             <div className={styles.tabBar}>
                 {topics.map(t => (
                     <button


### PR DESCRIPTION
## Summary
- show the currently selected topic in the dashboard header

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887eae433d883289b11c6ae013aaa86