### PR TITLE
Display water tank data

### DIFF
--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -172,17 +172,21 @@ function SensorDashboard() {
         }
         const deviceId = payload.deviceId || msg.deviceId || 'unknown';
         let data = payload;
-        if (topic === sensorTopic) {
+        if (topic === sensorTopic || topic === 'waterTank') {
             const norm = normalizeSensorData(payload);
             console.log('🔄 normalized sensor message:', norm);
-            const cleaned = filterNoise(norm);
-            if (!cleaned) {
-                console.log('🛑 message filtered out as noise', norm);
-                return;
+            if (topic === sensorTopic) {
+                const cleaned = filterNoise(norm);
+                if (!cleaned) {
+                    console.log('🛑 message filtered out as noise', norm);
+                    return;
+                }
+                data = cleaned;
+                console.log('💾 updating sensorData state with:', data);
+                setSensorData(data);
+            } else {
+                data = norm;
             }
-            data = cleaned;
-            console.log('💾 updating sensorData state with:', data);
-            setSensorData(data);
         }
         setDeviceData(prev => {
             const t = { ...(prev[topic] || {}) };

--- a/tests/DeviceTableWaterTank.test.jsx
+++ b/tests/DeviceTableWaterTank.test.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import DeviceTable from '../src/components/DeviceTable';
+
+const devices = {
+  tank1: {
+    level: 75,
+    pump: 'on',
+    health: { level: true, pump: true }
+  }
+};
+
+test('renders unknown sensor fields', () => {
+  render(<DeviceTable devices={devices} />);
+  expect(screen.getByText('level')).toBeInTheDocument();
+  expect(screen.getByText('pump')).toBeInTheDocument();
+  expect(screen.getByText('75.0')).toBeInTheDocument();
+  expect(screen.getByText('on')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- normalize `waterTank` messages in `SensorDashboard`
- add test to ensure DeviceTable renders unknown water tank sensors

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688903eaf4e883289ffa7697986097b8