### PR TITLE
Fix waterTank sensor filtering

### DIFF
--- a/src/components/DeviceTable.jsx
+++ b/src/components/DeviceTable.jsx
@@ -77,10 +77,29 @@ function DeviceTable({ devices = {} }) {
     );
 
     const sensorSet = new Set();
+    const knownFields = new Set([
+        'temperature','humidity','lux','tds','ec','ph',
+        'F1','F2','F3','F4','F5','F6','F7','F8','clear','nir'
+    ]);
+
     for (const data of Object.values(devices)) {
-        for (const key of Object.keys(data)) {
-            if (key === 'health') continue;
-            sensorSet.add(bandMap[key] || key);
+        if (Array.isArray(data.sensors)) {
+            for (const s of data.sensors) {
+                if (s && s.type) {
+                    sensorSet.add(bandMap[s.type] || s.type);
+                }
+            }
+            for (const key of Object.keys(data)) {
+                if (key === 'health' || key === 'sensors') continue;
+                if (!knownFields.has(key)) {
+                    sensorSet.add(bandMap[key] || key);
+                }
+            }
+        } else {
+            for (const key of Object.keys(data)) {
+                if (key === 'health') continue;
+                sensorSet.add(bandMap[key] || key);
+            }
         }
     }
 

--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -185,7 +185,7 @@ function SensorDashboard() {
                 console.log('💾 updating sensorData state with:', data);
                 setSensorData(data);
             } else {
-                data = norm;
+                data = { ...norm, sensors: payload.sensors };
             }
         }
         setDeviceData(prev => {


### PR DESCRIPTION
## Summary
- preserve raw sensor list for waterTank messages
- only display sensors explicitly included in the message when a sensor list exists

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889e5c9926883289213c935d9b2eed5