### PR TITLE
Abbreviate sensor names and shrink column

### DIFF
--- a/src/components/DeviceTable.jsx
+++ b/src/components/DeviceTable.jsx
@@ -143,6 +143,11 @@ function DeviceTable({ devices = {} }) {
         return { sensor, range, cells, model, rowColor };
     });
 
+    const sensorDisplayMap = {
+        temperature: 'Temp',
+        humidity: 'Hum',
+    };
+
     const modelCounts = {};
     for (const r of rows) {
         modelCounts[r.model] = (modelCounts[r.model] || 0) + 1;
@@ -163,8 +168,8 @@ function DeviceTable({ devices = {} }) {
             <table className={styles.table}>
                 <thead>
                     <tr>
-                        <th>Sensor model</th>
-                        <th>Sensor</th>
+                        <th className={styles.modelCell}>Model</th>
+                        <th className={styles.sensorCell}>Sensor</th>
                         <th>Min</th>
                         <th>Max</th>
                         {deviceIds.map(id => (
@@ -175,8 +180,17 @@ function DeviceTable({ devices = {} }) {
                 <tbody>
                     {rows.map(r => (
                         <tr key={r.sensor}>
-                            {r.rowSpan > 0 && <td rowSpan={r.rowSpan}>{r.model}</td>}
-                            <td style={{ backgroundColor: r.rowColor }}>{r.sensor}</td>
+                            {r.rowSpan > 0 && (
+                                <td rowSpan={r.rowSpan} className={styles.modelCell}>
+                                    {r.model}
+                                </td>
+                            )}
+                            <td
+                                className={styles.sensorCell}
+                                style={{ backgroundColor: r.rowColor }}
+                            >
+                                {sensorDisplayMap[r.sensor] || r.sensor}
+                            </td>
                             <td style={{ backgroundColor: r.rowColor }}>{r.range?.min ?? '-'}</td>
                             <td style={{ backgroundColor: r.rowColor }}>{r.range?.max ?? '-'}</td>
                             {r.cells.map((c, i) => (

--- a/src/components/DeviceTable.module.css
+++ b/src/components/DeviceTable.module.css
@@ -18,6 +18,18 @@
     background-color: #eef6ff;
 }
 
+.modelCell {
+    width: 9ch;
+    font-size: 0.9em;
+    white-space: nowrap;
+}
+
+.sensorCell {
+    width: 9ch;
+    font-size: 0.9em;
+    white-space: nowrap;
+}
+
 
 .cellWrapper {
     display: flex;

--- a/tests/DeviceTable.test.jsx
+++ b/tests/DeviceTable.test.jsx
@@ -25,9 +25,9 @@ const devices = {
   }
 };
 
-test('renders sensor model column and merged cells', () => {
+test('renders model column and merged cells', () => {
   const { container } = render(<DeviceTable devices={devices} />);
-  expect(screen.getByText('Sensor model')).toBeInTheDocument();
+  expect(screen.getByText('Model')).toBeInTheDocument();
   const shtCell = screen.getByText('SHT3x');
   expect(shtCell.closest('td')).toHaveAttribute('rowspan', '2');
   const asCell = screen.getByText('AS7341');
@@ -39,4 +39,10 @@ test('spectral sensor row has colored background', () => {
   render(<DeviceTable devices={devices} />);
   const cell = screen.getByText('415nm');
   expect(cell).toHaveStyle({ backgroundColor: '#8a2be222' });
+});
+
+test('displays abbreviated sensor names', () => {
+  render(<DeviceTable devices={devices} />);
+  expect(screen.getByText('Temp')).toBeInTheDocument();
+  expect(screen.getByText('Hum')).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- keep `Sensor` column narrow like `Model`
- abbreviate `temperature` -> `Temp` and `humidity` -> `Hum`
- update DeviceTable tests

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a05bd4b7c8328a5a352caf4294356