### PR TITLE
Add device filter above live spectrum chart

### DIFF
--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -257,9 +257,30 @@ function SensorDashboard() {
                     />
 
                     {activeTopic === sensorTopic && (
-                        <div className={styles.spectrumBarChartWrapper}>
-                            <SpectrumBarChart sensorData={sensorData} />
-                        </div>
+                        <>
+                            <div className={styles.filterRow}>
+                                <label className={styles.filterLabel}>
+                                    Device:
+                                    <select
+                                        className={styles.intervalSelect}
+                                        value={selectedDevice}
+                                        onChange={e => setSelectedDevice(e.target.value)}
+                                    >
+                                        {availableDevices.map(id => (
+                                            <option key={id} value={id}>{id}</option>
+                                        ))}
+                                    </select>
+                                </label>
+                            </div>
+                            <div className={styles.deviceLabel}>{selectedDevice}</div>
+                            <div className={styles.spectrumBarChartWrapper}>
+                                <SpectrumBarChart
+                                    sensorData={
+                                        deviceData[sensorTopic]?.[selectedDevice] || sensorData
+                                    }
+                                />
+                            </div>
+                        </>
                     )}
 
                     {(() => {

--- a/src/components/SensorDashboard.module.css
+++ b/src/components/SensorDashboard.module.css
@@ -103,6 +103,12 @@
     margin-left: 10px;
 }
 
+.deviceLabel {
+    text-align: center;
+    font-weight: bold;
+    margin-bottom: 10px;
+}
+
 .fieldSpacer {
     margin: 0 10px;
     font-weight: bold;


### PR DESCRIPTION
## Summary
- add device selection dropdown in live data section
- display the active device name above the SpectrumBarChart

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a1a8a097c8328ac08e282e0408f7b