### PR TITLE
Adjust device selector layout

### DIFF
--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -257,8 +257,9 @@ function SensorDashboard() {
                     />
 
                     {activeTopic === sensorTopic && (
-                        <>
-                            <div className={styles.filterRow}>
+                        <div className={styles.spectrumBarChartWrapper}>
+                            <div className={styles.spectrumHeaderRow}>
+                                <div className={styles.deviceLabel}>{selectedDevice}</div>
                                 <label className={styles.filterLabel}>
                                     Device:
                                     <select
@@ -272,15 +273,12 @@ function SensorDashboard() {
                                     </select>
                                 </label>
                             </div>
-                            <div className={styles.deviceLabel}>{selectedDevice}</div>
-                            <div className={styles.spectrumBarChartWrapper}>
-                                <SpectrumBarChart
-                                    sensorData={
-                                        deviceData[sensorTopic]?.[selectedDevice] || sensorData
-                                    }
-                                />
-                            </div>
-                        </>
+                            <SpectrumBarChart
+                                sensorData={
+                                    deviceData[sensorTopic]?.[selectedDevice] || sensorData
+                                }
+                            />
+                        </div>
                     )}
 
                     {(() => {

--- a/src/components/SensorDashboard.module.css
+++ b/src/components/SensorDashboard.module.css
@@ -106,6 +106,12 @@
 .deviceLabel {
     text-align: center;
     font-weight: bold;
+}
+
+.spectrumHeaderRow {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
     margin-bottom: 10px;
 }
 


### PR DESCRIPTION
## Summary
- align the Spectrum chart's device selector with the chart title

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bbd0ff80c832880f068f30f054efc