### PR TITLE
Adjust device selector layout

### DIFF
--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -257,8 +257,8 @@ function SensorDashboard() {
                     />
 
                     {activeTopic === sensorTopic && (
-                        <>
-                            <div className={styles.filterRow}>
+                        <div className={styles.spectrumBarChartWrapper}>
+                            <div className={styles.spectrumHeaderRow}>
                                 <label className={styles.filterLabel}>
                                     Device:
                                     <select
@@ -271,16 +271,14 @@ function SensorDashboard() {
                                         ))}
                                     </select>
                                 </label>
+                                <div className={styles.deviceLabel}>{selectedDevice}</div>
                             </div>
-                            <div className={styles.deviceLabel}>{selectedDevice}</div>
-                            <div className={styles.spectrumBarChartWrapper}>
-                                <SpectrumBarChart
-                                    sensorData={
-                                        deviceData[sensorTopic]?.[selectedDevice] || sensorData
-                                    }
-                                />
-                            </div>
-                        </>
+                            <SpectrumBarChart
+                                sensorData={
+                                    deviceData[sensorTopic]?.[selectedDevice] || sensorData
+                                }
+                            />
+                        </div>
                     )}
 
                     {(() => {

--- a/src/components/SensorDashboard.module.css
+++ b/src/components/SensorDashboard.module.css
@@ -106,7 +106,24 @@
 .deviceLabel {
     text-align: center;
     font-weight: bold;
+}
+
+.spectrumHeaderRow {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
     margin-bottom: 10px;
+}
+
+.spectrumHeaderRow .filterLabel {
+    margin-left: 0;
+    position: absolute;
+    left: 0;
+}
+
+.spectrumHeaderRow .deviceLabel {
+    flex: 1;
 }
 
 .fieldSpacer {


### PR DESCRIPTION
## Summary
- align the Spectrum chart's device selector with the chart title

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bbd0ff80c832880f068f30f054efc