### PR TITLE
Add divider below device table

### DIFF
--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -256,10 +256,33 @@ function SensorDashboard() {
                         }
                     />
 
+                    <div className={styles.tableDivider}></div>
+
                     {activeTopic === sensorTopic && (
-                        <div className={styles.spectrumBarChartWrapper}>
-                            <SpectrumBarChart sensorData={sensorData} />
-                        </div>
+                        <>
+                            <div className={styles.chartFilterRow}>
+                                <label className={styles.filterLabel}>
+                                    Device:
+                                    <select
+                                        className={styles.intervalSelect}
+                                        value={selectedDevice}
+                                        onChange={e => setSelectedDevice(e.target.value)}
+                                    >
+                                        {availableDevices.map(id => (
+                                            <option key={id} value={id}>{id}</option>
+                                        ))}
+                                    </select>
+                                </label>
+                            </div>
+                            <div className={styles.deviceLabel}>{selectedDevice}</div>
+                            <div className={styles.spectrumBarChartWrapper}>
+                                <SpectrumBarChart
+                                    sensorData={
+                                        deviceData[sensorTopic]?.[selectedDevice] || sensorData
+                                    }
+                                />
+                            </div>
+                        </>
                     )}
 
                     {(() => {

--- a/src/components/SensorDashboard.module.css
+++ b/src/components/SensorDashboard.module.css
@@ -34,6 +34,11 @@
     border-bottom: 2px solid #ccc;
     margin: 40px 0;
 }
+
+.tableDivider {
+    border-bottom: 1px solid #ccc;
+    margin: 20px 0;
+}
 .sensorGrid {
     display: flex;
     flex-wrap: wrap;
@@ -74,6 +79,10 @@
 .filterRow {
     margin-bottom: 10px;
 }
+
+.chartFilterRow {
+    margin-bottom: 5px;
+}
 .historyControls {
     border: 1px solid #ccc;
     padding: 10px;
@@ -101,6 +110,12 @@
 
 .intervalSelect {
     margin-left: 10px;
+}
+
+.deviceLabel {
+    text-align: center;
+    font-weight: bold;
+    margin-bottom: 10px;
 }
 
 .fieldSpacer {


### PR DESCRIPTION
## Summary
- insert a divider after `DeviceTable` to visually separate the live chart
- move the device filter closer to the chart using a new style

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a1a8a097c8328ac08e282e0408f7b