### PR TITLE
Support valueType-based sensor messages and DO readings

### DIFF
--- a/src/components/DeviceTable.jsx
+++ b/src/components/DeviceTable.jsx
@@ -45,7 +45,8 @@ const sensorFieldMap = {
     sht3x: ['temperature', 'humidity'],
     as7341: ['F1', 'F2', 'F3', 'F4', 'F5', 'F6', 'F7', 'F8', 'clear', 'nir'],
     tds: ['tds', 'ec'],
-    ph: ['ph']
+    ph: ['ph'],
+    do: ['do']
 };
 
 const fieldToSensor = Object.fromEntries(
@@ -61,6 +62,7 @@ const sensorModelMap = {
     tds: 'version 1.0',
     ec: 'version 1.0',
     ph: 'E-201',
+    do: 'DFROBOT',
 };
 
 for (const b of Object.values(bandMap)) {
@@ -78,7 +80,7 @@ function DeviceTable({ devices = {} }) {
 
     const sensorSet = new Set();
     const knownFields = new Set([
-        'temperature','humidity','lux','tds','ec','ph',
+        'temperature','humidity','lux','tds','ec','ph','do',
         'F1','F2','F3','F4','F5','F6','F7','F8','clear','nir'
     ]);
     const metaFields = new Set(['timestamp','deviceId','location']);
@@ -86,8 +88,9 @@ function DeviceTable({ devices = {} }) {
     for (const data of Object.values(devices)) {
         if (Array.isArray(data.sensors)) {
             for (const s of data.sensors) {
-                if (s && s.type) {
-                    sensorSet.add(bandMap[s.type] || s.type);
+                const type = s && (s.type || s.valueType);
+                if (type) {
+                    sensorSet.add(bandMap[type] || type);
                 }
             }
         }
@@ -104,6 +107,7 @@ function DeviceTable({ devices = {} }) {
         'VEML7700',
         'version 1.0',
         'E-201',
+        'DFROBOT',
         'AS7341',
     ];
 
@@ -142,6 +146,7 @@ function DeviceTable({ devices = {} }) {
     const sensorDisplayMap = {
         temperature: 'Temp',
         humidity: 'Hum',
+        do: 'DO',
     };
 
     const modelCounts = {};

--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -297,7 +297,7 @@ function SensorDashboard() {
                             F8: '680nm'
                         };
                         const knownFields = new Set([
-                            'temperature','humidity','lux','tds','ec','ph',
+                            'temperature','humidity','lux','tds','ec','ph','do',
                             'F1','F2','F3','F4','F5','F6','F7','F8','clear','nir'
                         ]);
                         const metaFields = new Set(['timestamp','deviceId','location']);
@@ -308,8 +308,9 @@ function SensorDashboard() {
                         for (const dev of Object.values(topicData)) {
                             if (Array.isArray(dev.sensors)) {
                                 for (const s of dev.sensors) {
-                                    if (s && s.type) {
-                                        sensors.add(bandMap[s.type] || s.type);
+                                    const type = s && (s.type || s.valueType);
+                                    if (type) {
+                                        sensors.add(bandMap[type] || type);
                                     }
                                 }
                             }

--- a/src/idealRangeConfig.js
+++ b/src/idealRangeConfig.js
@@ -23,6 +23,10 @@ const idealRangeConfig = {
         idealRange: { min: 5.8, max: 6.5 },
         description: 'pH affects nutrient absorption. 6.0 is optimal for basil.'
     },
+    do: {
+        idealRange: { min: 5, max: 8 },
+        description: 'Dissolved oxygen ideal range is roughly 5–8 mg/L.'
+    },
     '415nm': {
         idealRange: { min: 2, max: 50 },
         description: 'Supports early cell growth.',

--- a/src/utils.js
+++ b/src/utils.js
@@ -19,11 +19,12 @@ export function normalizeSensorData(data) {
 
     if (Array.isArray(data.sensors)) {
         for (const sensor of data.sensors) {
+            const type = sensor.type || sensor.valueType;
             const val = Number(sensor.value);
-            switch (sensor.type) {
+            switch (type) {
             case 'temperature':
             case 'humidity':
-                result[sensor.type] = {
+                result[type] = {
                         value: val,
                         unit: sensor.unit || ''
                 };
@@ -48,6 +49,13 @@ export function normalizeSensorData(data) {
                 break;
             case 'ph':
                 result.ph = {
+                        value: val,
+                        unit: sensor.unit || ''
+                };
+                break;
+            case 'dissolvedOxygen':
+            case 'do':
+                result.do = {
                         value: val,
                         unit: sensor.unit || ''
                 };
@@ -93,7 +101,7 @@ export function normalizeSensorData(data) {
         }
     }
         result.health = {};
-        for (const key in data.health) {
+        for (const key in (data.health || {})) {
             const val = data.health[key];
             const base = key.split('-')[0];
             result.health[base] = val === true || val === 'true' || val === 1;
@@ -111,6 +119,10 @@ export function normalizeSensorData(data) {
             result.ec = { value: Number(data.ec), unit: 'mS/cm' };
         if ('ph' in data)
             result.ph = { value: Number(data.ph), unit: '' };
+        if ('dissolvedOxygen' in data)
+            result.do = { value: Number(data.dissolvedOxygen), unit: 'mg/L' };
+        if ('do' in data)
+            result.do = { value: Number(data.do), unit: 'mg/L' };
 
         const mapping = {
             ch415: 'F1', ch445: 'F2', ch480: 'F3', ch515: 'F4',
@@ -148,7 +160,7 @@ export function transformAggregatedData(data) {
     if (!data || !Array.isArray(data.sensors)) return [];
     const map = {};
     for (const sensor of data.sensors) {
-        const type = sensor.type;
+        const type = sensor.type || sensor.valueType;
         const unit = sensor.unit || '';
         for (const entry of sensor.data || []) {
             const ts = Date.parse(entry.timestamp);
@@ -163,6 +175,7 @@ export function transformAggregatedData(data) {
                     tds: { value: 0, unit: 'ppm' },
                     ec: { value: 0, unit: 'mS/cm' },
                     ph: { value: 0, unit: '' },
+                    do: { value: 0, unit: 'mg/L' },
                 };
             }
             const out = map[ts];
@@ -183,6 +196,10 @@ export function transformAggregatedData(data) {
                     break;
                 case 'ph':
                     out.ph = { value: Number(val), unit };
+                    break;
+                case 'dissolvedOxygen':
+                case 'do':
+                    out.do = { value: Number(val), unit };
                     break;
                 case '415nm':
                     out.F1 = Number(val);

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -105,6 +105,20 @@ test('handles ph sensor readings', () => {
     expect(result.ph.value).toBe(6.2);
 });
 
+test('supports sensors using valueType field', () => {
+    const raw = {
+        sensors: [
+            { sensorName: 'HailegeTDS', valueType: 'tds', value: 535.7, unit: 'ppm' },
+            { sensorName: 'DS18B20', valueType: 'temperature', value: 24.3, unit: '°C' }
+        ],
+        health: { tds: true, temp: true }
+    };
+    const result = normalizeSensorData(raw);
+    expect(result.tds.value).toBeCloseTo(535.7);
+    expect(result.temperature.value).toBe(24.3);
+    expect(result.health.tds).toBe(true);
+});
+
 test('filterNoise discards out of range values', () => {
     const clean = {
         F1: 100, F2: 100, F3: 100, F4: 100,
@@ -147,4 +161,15 @@ test('transformAggregatedData converts API response', () => {
     expect(entry.temperature.value).toBe(27.5);
     expect(entry.F3).toBe(3);
     expect(entry.nir).toBe(10);
+});
+
+test('transformAggregatedData handles valueType and DO sensor', () => {
+    const raw = {
+        sensors: [
+            { valueType: 'dissolvedOxygen', unit: 'mg/L', data: [{ timestamp: '2025-07-25T09:00:04Z', value: 5.5 }] }
+        ]
+    };
+    const result = transformAggregatedData(raw);
+    expect(result.length).toBe(1);
+    expect(result[0].do.value).toBe(5.5);
 });


### PR DESCRIPTION
## Summary
- allow `normalizeSensorData` and downstream views to handle sensors that report a `valueType` instead of `type`
- surface dissolved oxygen readings and ranges in DeviceTable and related configs

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_688f47c4a53c832882d71d4d8dd19db9