### PR TITLE
Support valueType-based sensor messages and DO readings

### DIFF
--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -297,7 +297,7 @@ function SensorDashboard() {
                             F8: '680nm'
                         };
                         const knownFields = new Set([
-                            'temperature','humidity','lux','tds','ec','ph',
+                            'temperature','humidity','lux','tds','ec','ph','do',
                             'F1','F2','F3','F4','F5','F6','F7','F8','clear','nir'
                         ]);
                         const metaFields = new Set(['timestamp','deviceId','location']);
@@ -308,8 +308,9 @@ function SensorDashboard() {
                         for (const dev of Object.values(topicData)) {
                             if (Array.isArray(dev.sensors)) {
                                 for (const s of dev.sensors) {
-                                    if (s && s.type) {
-                                        sensors.add(bandMap[s.type] || s.type);
+                                    const type = s && (s.type || s.valueType);
+                                    if (type) {
+                                        sensors.add(bandMap[type] || type);
                                     }
                                 }
                             }

--- a/src/idealRangeConfig.js
+++ b/src/idealRangeConfig.js
@@ -23,6 +23,10 @@ const idealRangeConfig = {
         idealRange: { min: 5.8, max: 6.5 },
         description: 'pH affects nutrient absorption. 6.0 is optimal for basil.'
     },
+    do: {
+        idealRange: { min: 5, max: 8 },
+        description: 'Dissolved oxygen ideal range is roughly 5–8 mg/L.'
+    },
     '415nm': {
         idealRange: { min: 2, max: 50 },
         description: 'Supports early cell growth.',

--- a/src/utils.js
+++ b/src/utils.js
@@ -19,11 +19,12 @@ export function normalizeSensorData(data) {
 
     if (Array.isArray(data.sensors)) {
         for (const sensor of data.sensors) {
+            const type = sensor.type || sensor.valueType;
             const val = Number(sensor.value);
-            switch (sensor.type) {
+            switch (type) {
             case 'temperature':
             case 'humidity':
-                result[sensor.type] = {
+                result[type] = {
                         value: val,
                         unit: sensor.unit || ''
                 };
@@ -48,6 +49,13 @@ export function normalizeSensorData(data) {
                 break;
             case 'ph':
                 result.ph = {
+                        value: val,
+                        unit: sensor.unit || ''
+                };
+                break;
+            case 'dissolvedOxygen':
+            case 'do':
+                result.do = {
                         value: val,
                         unit: sensor.unit || ''
                 };
@@ -93,7 +101,7 @@ export function normalizeSensorData(data) {
         }
     }
         result.health = {};
-        for (const key in data.health) {
+        for (const key in (data.health || {})) {
             const val = data.health[key];
             const base = key.split('-')[0];
             result.health[base] = val === true || val === 'true' || val === 1;
@@ -111,6 +119,10 @@ export function normalizeSensorData(data) {
             result.ec = { value: Number(data.ec), unit: 'mS/cm' };
         if ('ph' in data)
             result.ph = { value: Number(data.ph), unit: '' };
+        if ('dissolvedOxygen' in data)
+            result.do = { value: Number(data.dissolvedOxygen), unit: 'mg/L' };
+        if ('do' in data)
+            result.do = { value: Number(data.do), unit: 'mg/L' };
 
         const mapping = {
             ch415: 'F1', ch445: 'F2', ch480: 'F3', ch515: 'F4',
@@ -148,7 +160,7 @@ export function transformAggregatedData(data) {
     if (!data || !Array.isArray(data.sensors)) return [];
     const map = {};
     for (const sensor of data.sensors) {
-        const type = sensor.type;
+        const sensorType = sensor.type || sensor.valueType;
         const unit = sensor.unit || '';
         for (const entry of sensor.data || []) {
             const ts = Date.parse(entry.timestamp);
@@ -163,14 +175,15 @@ export function transformAggregatedData(data) {
                     tds: { value: 0, unit: 'ppm' },
                     ec: { value: 0, unit: 'mS/cm' },
                     ph: { value: 0, unit: '' },
+                    do: { value: 0, unit: 'mg/L' },
                 };
             }
             const out = map[ts];
             const val = entry.value;
-            switch (type) {
+            switch (sensorType) {
                 case 'temperature':
                 case 'humidity':
-                    out[type] = { value: Number(val), unit };
+                    out[sensorType] = { value: Number(val), unit };
                     break;
                 case 'light':
                     out.lux = { value: Number(val), unit };
@@ -183,6 +196,10 @@ export function transformAggregatedData(data) {
                     break;
                 case 'ph':
                     out.ph = { value: Number(val), unit };
+                    break;
+                case 'dissolvedOxygen':
+                case 'do':
+                    out.do = { value: Number(val), unit };
                     break;
                 case '415nm':
                     out.F1 = Number(val);

--- a/tests/DeviceTable.test.jsx
+++ b/tests/DeviceTable.test.jsx
@@ -25,9 +25,9 @@ const devices = {
   }
 };
 
-test('renders model column and merged cells', () => {
+test('renders sensorName column and merged cells', () => {
   const { container } = render(<DeviceTable devices={devices} />);
-  expect(screen.getByText('Model')).toBeInTheDocument();
+  expect(screen.getByText('Sensor Name')).toBeInTheDocument();
   const shtCell = screen.getByText('SHT3x');
   expect(shtCell.closest('td')).toHaveAttribute('rowspan', '2');
   const asCell = screen.getByText('AS7341');

--- a/tests/DeviceTableWaterTank.test.jsx
+++ b/tests/DeviceTableWaterTank.test.jsx
@@ -11,10 +11,33 @@ const devices = {
   }
 };
 
+const devicesWithNames = {
+  tank1: {
+    sensors: [
+      { sensorName: 'HailegeTDS', valueType: 'tds', value: 500, unit: 'ppm' },
+      { sensorName: '', valueType: 'ec', value: 0.8, unit: 'mS/cm', source: 'HailegeTDS' },
+      { sensorName: 'DS18B20', valueType: 'temperature', value: 24.3, unit: '°C' },
+      { sensorName: 'DFROBOT', valueType: 'dissolvedOxygen', value: 3.1, unit: 'mg/L' }
+    ],
+    tds: { value: 500, unit: 'ppm' },
+    ec: { value: 0.8, unit: 'mS/cm' },
+    temperature: { value: 24.3, unit: '°C' },
+    do: { value: 3.1, unit: 'mg/L' },
+    health: { tds: true, sht3x: true, do: true }
+  }
+};
+
 test('renders unknown sensor fields', () => {
   render(<DeviceTable devices={devices} />);
-  expect(screen.getByText('level')).toBeInTheDocument();
-  expect(screen.getByText('pump')).toBeInTheDocument();
+  expect(screen.getAllByText('level').length).toBeGreaterThan(0);
+  expect(screen.getAllByText('pump').length).toBeGreaterThan(0);
   expect(screen.getByText('75.0')).toBeInTheDocument();
   expect(screen.getByText('on')).toBeInTheDocument();
+});
+
+test('renders sensor names from sensors array', () => {
+  render(<DeviceTable devices={devicesWithNames} />);
+  expect(screen.getByText('HailegeTDS')).toBeInTheDocument();
+  expect(screen.getByText('DS18B20')).toBeInTheDocument();
+  expect(screen.getByText('DFROBOT')).toBeInTheDocument();
 });

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -105,6 +105,20 @@ test('handles ph sensor readings', () => {
     expect(result.ph.value).toBe(6.2);
 });
 
+test('supports sensors using valueType field', () => {
+    const raw = {
+        sensors: [
+            { sensorName: 'HailegeTDS', valueType: 'tds', value: 535.7, unit: 'ppm' },
+            { sensorName: 'DS18B20', valueType: 'temperature', value: 24.3, unit: '°C' }
+        ],
+        health: { tds: true, temp: true }
+    };
+    const result = normalizeSensorData(raw);
+    expect(result.tds.value).toBeCloseTo(535.7);
+    expect(result.temperature.value).toBe(24.3);
+    expect(result.health.tds).toBe(true);
+});
+
 test('filterNoise discards out of range values', () => {
     const clean = {
         F1: 100, F2: 100, F3: 100, F4: 100,
@@ -147,4 +161,15 @@ test('transformAggregatedData converts API response', () => {
     expect(entry.temperature.value).toBe(27.5);
     expect(entry.F3).toBe(3);
     expect(entry.nir).toBe(10);
+});
+
+test('transformAggregatedData handles valueType and DO sensor', () => {
+    const raw = {
+        sensors: [
+            { valueType: 'dissolvedOxygen', unit: 'mg/L', data: [{ timestamp: '2025-07-25T09:00:04Z', value: 5.5 }] }
+        ]
+    };
+    const result = transformAggregatedData(raw);
+    expect(result.length).toBe(1);
+    expect(result[0].do.value).toBe(5.5);
 });


### PR DESCRIPTION
## Summary
- allow `normalizeSensorData` and downstream views to handle sensors that report a `valueType` instead of `type`
- surface dissolved oxygen readings and ranges in DeviceTable and related configs
- display incoming `sensorName` values in the DeviceTable's first column
- define `sensorType` in `transformAggregatedData` so the aggregator can switch on sensors without a `type` field

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f47c4a53c832882d71d4d8dd19db9