### PR TITLE
Add dissolved oxygen range and display

### DIFF
--- a/src/components/DeviceTable.jsx
+++ b/src/components/DeviceTable.jsx
@@ -71,6 +71,13 @@ for (const key of Object.keys(bandMap)) {
 sensorModelMap.clear = 'AS7341';
 sensorModelMap.nir = 'AS7341';
 
+const sensorDisplayMap = {
+    temperature: 'Temp',
+    humidity: 'Hum',
+    do: 'DO',
+    dissolvedOxygen: 'DO',
+};
+
 function DeviceTable({ devices = {} }) {
     const deviceIds = Object.keys(devices);
 
@@ -124,7 +131,7 @@ function DeviceTable({ devices = {} }) {
                         {rows.map(r => (
                             <tr key={r.info.valueType}>
                                 <td className={styles.modelCell}>{r.info.sensorName}</td>
-                                <td className={styles.sensorCell}>{r.info.valueType}</td>
+                                <td className={styles.sensorCell}>{sensorDisplayMap[r.info.valueType] || r.info.valueType}</td>
                                 <td>{r.range?.min ?? '-'}</td>
                                 <td>{r.range?.max ?? '-'}</td>
                                 {r.cells.map((c, i) => (
@@ -217,12 +224,6 @@ function DeviceTable({ devices = {} }) {
         });
         return { sensor, range, cells, sensorName, rowColor };
     });
-
-    const sensorDisplayMap = {
-        temperature: 'Temp',
-        humidity: 'Hum',
-        do: 'DO',
-    };
 
     const nameCounts = {};
     for (const r of rows) {

--- a/src/idealRangeConfig.js
+++ b/src/idealRangeConfig.js
@@ -27,6 +27,10 @@ const idealRangeConfig = {
         idealRange: { min: 5, max: 8 },
         description: 'Dissolved oxygen ideal range is roughly 5–8 mg/L.'
     },
+    dissolvedOxygen: {
+        idealRange: { min: 5, max: 8 },
+        description: 'Dissolved oxygen ideal range is roughly 5–8 mg/L.'
+    },
     '415nm': {
         idealRange: { min: 2, max: 50 },
         description: 'Supports early cell growth.',

--- a/tests/DeviceTableWaterTank.test.jsx
+++ b/tests/DeviceTableWaterTank.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import DeviceTable from '../src/components/DeviceTable';
 
@@ -40,6 +40,7 @@ test('renders sensor names from sensors array', () => {
   expect(screen.queryAllByText('HailegeTDS')).not.toHaveLength(0);
   expect(screen.queryAllByText('DS18B20')).not.toHaveLength(0);
   expect(screen.queryAllByText('DFROBOT')).not.toHaveLength(0);
-
-
+  const doRow = screen.getByText('DO').closest('tr');
+  expect(within(doRow).getByText('5')).toBeInTheDocument();
+  expect(within(doRow).getByText('8')).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- add ideal range entry for dissolved oxygen
- show dissolved oxygen as DO in tables
- verify dissolved oxygen row renders expected min/max

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_688f8b8ec6d48328b8a7ada618c44f8d