### PR TITLE
Group dashboard data by system

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import styles from './Header.module.css';
 
-function Header({ topic }) {
+function Header({ system }) {
     const [now, setNow] = useState(() => new Date());
 
     useEffect(() => {
@@ -11,7 +11,7 @@ function Header({ topic }) {
 
     return (
         <header className={styles.header}>
-            <h1 className={styles.title}>{topic} Dashboard</h1>
+            <h1 className={styles.title}>{system} Dashboard</h1>
             <div className={styles.time}>{now.toLocaleTimeString()}</div>
         </header>
     );

--- a/tests/Header.test.jsx
+++ b/tests/Header.test.jsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import Header from '../src/components/Header';
 
-test('renders topic title', () => {
-    render(<Header topic="my/topic" />);
-    expect(screen.getByText('my/topic Dashboard')).toBeInTheDocument();
+test('renders system title', () => {
+    render(<Header system="S01" />);
+    expect(screen.getByText('S01 Dashboard')).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- Organize incoming STOMP messages by system ID and merge device data across topics
- Render dashboard tabs per system and display aggregated devices in each tab
- Update header and tests to reference system-based dashboards

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68903cf794b48328876d6e406f12493f