### PR TITLE
Add sidebar main layout and fix react-router-dom alias

### DIFF
--- a/src/compat/react-router-dom.jsx
+++ b/src/compat/react-router-dom.jsx
@@ -15,3 +15,7 @@ export function Route({ element }) {
 export function Outlet() {
     return null;
 }
+
+export function Sidebar() {
+    return null;
+}

--- a/src/layout/MainLayout.jsx
+++ b/src/layout/MainLayout.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Sidebar, Outlet } from 'react-router-dom';
+
+export default function MainLayout() {
+    return (
+        <div style={{ display: 'flex' }}>
+            <Sidebar />
+            <main style={{ flexGrow: 1 }}>
+                <Outlet />
+            </main>
+        </div>
+    );
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,7 +8,7 @@ export default defineConfig({
     plugins: [react()],
     resolve: {
         alias: {
-            'react-router-dom': path.resolve(__dirname, 'src/compat/react-router-dom.js'),
+            'react-router-dom': path.resolve(__dirname, 'src/compat/react-router-dom.jsx'),
         },
     },
 });

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -9,7 +9,7 @@ export default defineConfig({
     },
     resolve: {
         alias: {
-            'react-router-dom': path.resolve(__dirname, 'src/compat/react-router-dom.js'),
+            'react-router-dom': path.resolve(__dirname, 'src/compat/react-router-dom.jsx'),
         },
     },
 });


### PR DESCRIPTION
## Summary
- add MainLayout component with Sidebar and Outlet
- rename react-router-dom compatibility shim to .jsx and include Sidebar export
- point Vite/Vitest aliases to new shim

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894c04be7c88328888a662ab04ad56a