### PR TITLE
Show sensor dashboard on dashboard route

### DIFF
--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,11 +1,8 @@
 import React from 'react';
+import SensorDashboard from '../components/SensorDashboard';
 
 function Dashboard() {
-    return (
-        <div>
-            Dashboard
-        </div>
-    );
+    return <SensorDashboard />;
 }
 
 export default Dashboard;


### PR DESCRIPTION
## Summary
- Render the full sensor dashboard when navigating to the Dashboard page

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894d7f1c7fc832890e3f0e61a339480