### PR TITLE
Add ideal range notes to documentation page

### DIFF
--- a/src/pages/Documentation.jsx
+++ b/src/pages/Documentation.jsx
@@ -1,9 +1,25 @@
 import React from 'react';
+import idealRangeConfig from '../idealRangeConfig';
 
 function Documentation() {
     return (
         <div>
-            Documentation
+            <h1>Ideal Ranges</h1>
+            {Object.entries(idealRangeConfig).map(([key, value]) => (
+                <section key={key}>
+                    <h2>{key}</h2>
+                    <p>{value.description}</p>
+                    {value.idealRange && (
+                        <p>
+                            Ideal range: {value.idealRange.min}–{value.idealRange.max}
+                        </p>
+                    )}
+                    {value.spectralRange && (
+                        <p>Spectral range: {value.spectralRange}</p>
+                    )}
+                    {value.color && <p>Color: {value.color}</p>}
+                </section>
+            ))}
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- Display all ideal range information on the docs page

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6894e035506c8328b32e0da4ae3affca