### PR TITLE
Refactor SensorDashboard into presentational components

### DIFF
--- a/src/components/dashboard/NotesBlock.jsx
+++ b/src/components/dashboard/NotesBlock.jsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import styles from '../SensorDashboard.module.css';
+import idealRangeConfig from '../../idealRangeConfig.js';
+
+function NotesBlock({ mergedDevices = {} }) {
+  const bandMap = {
+    F1: '415nm',
+    F2: '445nm',
+    F3: '480nm',
+    F4: '515nm',
+    F5: '555nm',
+    F6: '590nm',
+    F7: '630nm',
+    F8: '680nm'
+  };
+  const knownFields = new Set([
+    'temperature',
+    'humidity',
+    'lux',
+    'tds',
+    'ec',
+    'ph',
+    'do',
+    'F1',
+    'F2',
+    'F3',
+    'F4',
+    'F5',
+    'F6',
+    'F7',
+    'F8',
+    'clear',
+    'nir'
+  ]);
+  const metaFields = new Set(['timestamp', 'deviceId', 'location']);
+
+  const sensors = new Set();
+  for (const dev of Object.values(mergedDevices)) {
+    if (Array.isArray(dev?.sensors)) {
+      for (const s of dev.sensors) {
+        const type = s && (s.type || s.valueType);
+        if (type) sensors.add(bandMap[type] || type);
+      }
+    }
+    for (const key of Object.keys(dev || {})) {
+      if (key === 'health' || key === 'sensors') continue;
+      if (metaFields.has(key)) continue;
+      if (Array.isArray(dev?.sensors) && knownFields.has(key)) continue;
+      sensors.add(bandMap[key] || key);
+    }
+  }
+
+  const notes = [];
+  for (const key of sensors) {
+    const cfg = idealRangeConfig[key];
+    if (cfg?.description) notes.push(`${key}: ${cfg.description}`);
+  }
+
+  if (!notes.length) return null;
+
+  return (
+    <div className={styles.noteBlock}>
+      <div className={styles.noteTitle}>Notes:</div>
+      <ul>
+        {notes.map((n, i) => (
+          <li key={i}>{n}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default NotesBlock;

--- a/src/components/dashboard/ReportCharts.jsx
+++ b/src/components/dashboard/ReportCharts.jsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import HistoricalBlueBandChart from '../HistoricalBlueBandChart';
+import HistoricalRedBandChart from '../HistoricalRedBandChart';
+import HistoricalClearLuxChart from '../HistoricalClearLuxChart';
+import HistoricalPhChart from '../HistoricalPhChart';
+import HistoricalEcTdsChart from '../HistoricalEcTdsChart';
+import HistoricalTemperatureChart from '../HistoricalTemperatureChart';
+import HistoricalDoChart from '../HistoricalDoChart';
+import styles from '../SensorDashboard.module.css';
+
+function ReportCharts({
+  showTempHum,
+  showBlue,
+  showRed,
+  showClearLux,
+  showPh,
+  showEcTds,
+  showDo,
+  rangeData,
+  tempRangeData,
+  phRangeData,
+  ecTdsRangeData,
+  doRangeData,
+  xDomain
+}) {
+  return (
+    <>
+      {(showTempHum || showBlue) && (
+        <div className={styles.historyChartsRow}>
+          {showTempHum && (
+            <div className={styles.historyChartColumn}>
+              <h3 className={styles.sectionTitle}>Temperature</h3>
+              <div className={styles.dailyTempChartWrapper}>
+                <HistoricalTemperatureChart data={tempRangeData} xDomain={xDomain} />
+              </div>
+            </div>
+          )}
+          {showBlue && (
+            <div className={styles.historyChartColumn}>
+              <h3 className={styles.sectionTitle}>Blue Bands</h3>
+              <div className={styles.blueBandChartWrapper}>
+                <HistoricalBlueBandChart data={rangeData} xDomain={xDomain} />
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {(showRed || showClearLux) && (
+        <div className={styles.historyChartsRow}>
+          {showRed && (
+            <div className={styles.historyChartColumn}>
+              <h3 className={styles.sectionTitle}>Red Bands</h3>
+              <div className={styles.redBandChartWrapper}>
+                <HistoricalRedBandChart data={rangeData} xDomain={xDomain} />
+              </div>
+            </div>
+          )}
+          {showClearLux && (
+            <div className={styles.historyChartColumn}>
+              <h3 className={styles.sectionTitle}>Lux_Clear</h3>
+              <div className={styles.clearLuxChartWrapper}>
+                <HistoricalClearLuxChart data={rangeData} xDomain={xDomain} />
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {(showPh || showEcTds) && (
+        <div className={styles.historyChartsRow}>
+          {showPh && (
+            <div className={styles.historyChartColumn}>
+              <h3 className={styles.sectionTitle}>pH</h3>
+              <div className={styles.phChartWrapper}>
+                <HistoricalPhChart data={phRangeData} xDomain={xDomain} />
+              </div>
+            </div>
+          )}
+          {showEcTds && (
+            <div className={styles.historyChartColumn}>
+              <h3 className={styles.sectionTitle}>EC &amp; TDS</h3>
+              <div className={styles.ecTdsChartWrapper}>
+                <HistoricalEcTdsChart data={ecTdsRangeData} xDomain={xDomain} />
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {showDo && (
+        <div className={styles.historyChartsRow}>
+          <div className={styles.historyChartColumn}>
+            <h3 className={styles.sectionTitle}>Dissolved Oxygen</h3>
+            <div className={styles.doChartWrapper}>
+              <HistoricalDoChart data={doRangeData} xDomain={xDomain} />
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+export default ReportCharts;

--- a/src/components/dashboard/ReportControls.jsx
+++ b/src/components/dashboard/ReportControls.jsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import styles from '../SensorDashboard.module.css';
+
+function ReportControls({
+  fromDate,
+  toDate,
+  onFromDateChange,
+  onToDateChange,
+  onNow,
+  onApply,
+  selectedDevice,
+  availableBaseIds = [],
+  onDeviceChange,
+  autoRefresh,
+  onAutoRefreshChange,
+  refreshInterval,
+  onRefreshIntervalChange,
+  rangeLabel
+}) {
+  return (
+    <fieldset className={styles.historyControls}>
+      <legend className={styles.historyLegend}>Historical Range</legend>
+      <div className={styles.filterRow}>
+        <label>
+          From:
+          <input type="datetime-local" value={fromDate} onChange={onFromDateChange} />
+        </label>
+        <span className={styles.fieldSpacer}>–</span>
+        <label className={styles.filterLabel}>
+          To:
+          <input type="datetime-local" value={toDate} onChange={onToDateChange} />
+        </label>
+        <button type="button" className={styles.nowButton} onClick={onNow}>
+          Now
+        </button>
+        <button type="button" className={styles.applyButton} onClick={onApply}>
+          Apply
+        </button>
+      </div>
+
+      <div className={styles.filterRow}>
+        <label className={styles.filterLabel}>
+          Device:
+          <select className={styles.intervalSelect} value={selectedDevice} onChange={onDeviceChange}>
+            {availableBaseIds.map((id) => (
+              <option key={id} value={id}>
+                {id}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <div className={styles.filterRow}>
+        <label className={styles.filterLabel}>
+          <input type="checkbox" checked={autoRefresh} onChange={onAutoRefreshChange} />{' '}
+          Auto Refresh
+        </label>
+        <select
+          className={styles.intervalSelect}
+          value={refreshInterval}
+          onChange={onRefreshIntervalChange}
+          disabled={!autoRefresh}
+        >
+          <option value={60000}>1min</option>
+          <option value={300000}>5min</option>
+          <option value={600000}>10min</option>
+          <option value={1800000}>30min</option>
+          <option value={3600000}>1h</option>
+        </select>
+      </div>
+
+      <div className={styles.rangeLabel}>{rangeLabel}</div>
+    </fieldset>
+  );
+}
+
+export default ReportControls;

--- a/src/components/dashboard/SystemTabs.jsx
+++ b/src/components/dashboard/SystemTabs.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import styles from '../SensorDashboard.module.css';
+
+function SystemTabs({ systems = [], activeSystem, onChange }) {
+  return (
+    <div className={styles.tabBar}>
+      {systems.map((system) => (
+        <button
+          key={system}
+          className={`${styles.tab} ${activeSystem === system ? styles.activeTab : ''}`}
+          onClick={() => onChange(system)}
+        >
+          {system}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export default SystemTabs;

--- a/src/components/dashboard/TopicSection.jsx
+++ b/src/components/dashboard/TopicSection.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import DeviceTable from '../DeviceTable';
+import styles from '../SensorDashboard.module.css';
+
+function TopicSection({ systemTopics = {} }) {
+  return (
+    <>
+      {Object.entries(systemTopics).map(([topic, devices]) => (
+        <div key={topic} className={styles.deviceGroup}>
+          <h3 className={styles.topicTitle}>{topic}</h3>
+          <DeviceTable devices={devices} />
+        </div>
+      ))}
+    </>
+  );
+}
+
+export default TopicSection;

--- a/src/components/dashboard/VerticalTabs.jsx
+++ b/src/components/dashboard/VerticalTabs.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import styles from '../SensorDashboard.module.css';
+
+function VerticalTabs({ activeTab, onChange }) {
+  return (
+    <div className={styles.verticalTabBar}>
+      <button
+        className={`${styles.verticalTab} ${activeTab === 'live' ? styles.activeVerticalTab : ''}`}
+        onClick={() => onChange('live')}
+      >
+        Live
+      </button>
+      <button
+        className={`${styles.verticalTab} ${activeTab === 'report' ? styles.activeVerticalTab : ''}`}
+        onClick={() => onChange('report')}
+      >
+        Report
+      </button>
+    </div>
+  );
+}
+
+export default VerticalTabs;


### PR DESCRIPTION
## Summary
- Add presentational dashboard components: SystemTabs, VerticalTabs, TopicSection, ReportControls, ReportCharts, and NotesBlock
- Rewrite SensorDashboard to orchestrate new components and clean up imports

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896eaa1d3f883288d319afb6c290071