### PR TITLE
refactor: centralize dashboard constants and utilities

### DIFF
--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -11,16 +11,8 @@ import TopicSection from "./dashboard/TopicSection";
 import ReportControls from "./dashboard/ReportControls";
 import ReportCharts from "./dashboard/ReportCharts";
 import NotesBlock from "./dashboard/NotesBlock";
-
-const SENSOR_TOPIC = "growSensors";
-const topics = [SENSOR_TOPIC, "rootImages", "waterOutput", "waterTank"];
-
-// Format date for <input type="datetime-local">
-function toLocalInputValue(date) {
-    const tz = date.getTimezoneOffset() * 60000;
-    const local = new Date(date.getTime() - tz);
-    return local.toISOString().slice(0, 16);
-}
+import {SENSOR_TOPIC, topics} from "./dashboard/dashboard.constants";
+import {toLocalInputValue, formatTime} from "./dashboard/dashboard.utils";
 
 function SensorDashboard() {
     const [activeSystem, setActiveSystem] = useState("S01");
@@ -59,14 +51,6 @@ function SensorDashboard() {
   }, [availableBaseIds, selectedDevice]);
 
   // mergedDevices and availableBaseIds are provided by useLiveDevices
-
-
-    const formatTime = (t) => {
-        const d = new Date(t);
-        return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')} ${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
-    };
-
-
 
   // Figure out which report sections to show based on selected device's sensor types
     const sensorTypesForSelected = useMemo(() => {

--- a/src/components/dashboard/NotesBlock.jsx
+++ b/src/components/dashboard/NotesBlock.jsx
@@ -1,37 +1,9 @@
 import React from 'react';
 import styles from '../SensorDashboard.module.css';
 import idealRangeConfig from '../../idealRangeConfig.js';
+import {bandMap, knownFields} from './dashboard.constants';
 
 function NotesBlock({ mergedDevices = {} }) {
-  const bandMap = {
-    F1: '415nm',
-    F2: '445nm',
-    F3: '480nm',
-    F4: '515nm',
-    F5: '555nm',
-    F6: '590nm',
-    F7: '630nm',
-    F8: '680nm'
-  };
-  const knownFields = new Set([
-    'temperature',
-    'humidity',
-    'lux',
-    'tds',
-    'ec',
-    'ph',
-    'do',
-    'F1',
-    'F2',
-    'F3',
-    'F4',
-    'F5',
-    'F6',
-    'F7',
-    'F8',
-    'clear',
-    'nir'
-  ]);
   const metaFields = new Set(['timestamp', 'deviceId', 'location']);
 
   const sensors = new Set();

--- a/src/components/dashboard/dashboard.constants.js
+++ b/src/components/dashboard/dashboard.constants.js
@@ -1,0 +1,33 @@
+export const SENSOR_TOPIC = "growSensors";
+export const topics = [SENSOR_TOPIC, "rootImages", "waterOutput", "waterTank"];
+
+export const bandMap = {
+  F1: "415nm",
+  F2: "445nm",
+  F3: "480nm",
+  F4: "515nm",
+  F5: "555nm",
+  F6: "590nm",
+  F7: "630nm",
+  F8: "680nm"
+};
+
+export const knownFields = new Set([
+  "temperature",
+  "humidity",
+  "lux",
+  "tds",
+  "ec",
+  "ph",
+  "do",
+  "F1",
+  "F2",
+  "F3",
+  "F4",
+  "F5",
+  "F6",
+  "F7",
+  "F8",
+  "clear",
+  "nir"
+]);

--- a/src/components/dashboard/dashboard.utils.js
+++ b/src/components/dashboard/dashboard.utils.js
@@ -1,0 +1,10 @@
+export function toLocalInputValue(date) {
+  const tz = date.getTimezoneOffset() * 60000;
+  const local = new Date(date.getTime() - tz);
+  return local.toISOString().slice(0, 16);
+}
+
+export function formatTime(t) {
+  const d = new Date(t);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")} ${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+}

--- a/src/components/dashboard/useLiveDevices.js
+++ b/src/components/dashboard/useLiveDevices.js
@@ -1,8 +1,7 @@
 import {useCallback, useMemo, useState} from "react";
 import {filterNoise, normalizeSensorData} from "../../utils";
 import {useStomp} from "../../hooks/useStomp";
-
-const SENSOR_TOPIC = "growSensors";
+import {SENSOR_TOPIC} from "./dashboard.constants";
 
 export function useLiveDevices(topics, activeSystem) {
     const [deviceData, setDeviceData] = useState({});


### PR DESCRIPTION
## Summary
- consolidate dashboard constants into `dashboard.constants.js`
- add `dashboard.utils.js` for reusable formatting helpers
- update dashboard components to use new modules

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6896ef3ad048832895f629b821d5545a