### PR TITLE
Fix SpectrumBarChart device filter

### DIFF
--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -111,7 +111,7 @@ function SensorDashboard() {
 
                                 <div className={styles.spectrumBarChartWrapper}>
                   {/* Use flattened/normalized data only */}
-                                    <SpectrumBarChart sensorData={sensorData}/>
+                                    <SpectrumBarChart sensorData={sensorData[selectedDevice]}/>
                                 </div>
                             </>
                         )}

--- a/src/components/dashboard/useLiveDevices.js
+++ b/src/components/dashboard/useLiveDevices.js
@@ -22,7 +22,7 @@ export function useLiveDevices(topics, activeSystem) {
             const normalized = normalizeSensorData(payload);
             const cleaned = topic === SENSOR_TOPIC ? filterNoise(normalized) : normalized;
             if (cleaned && topic === SENSOR_TOPIC) {
-                setSensorData(cleaned);
+                setSensorData(prev => ({...prev, [baseId]: cleaned}));
             }
         }
 

--- a/tests/useLiveDevices.test.jsx
+++ b/tests/useLiveDevices.test.jsx
@@ -1,0 +1,40 @@
+import { renderHook, act } from '@testing-library/react';
+import { vi } from 'vitest';
+import { useLiveDevices } from '../src/components/dashboard/useLiveDevices';
+import { SENSOR_TOPIC } from '../src/components/dashboard/dashboard.constants';
+
+// Mock useStomp to capture the message handler
+vi.mock('../src/hooks/useStomp', () => ({
+  useStomp: (_topics, onMessage) => {
+    global.__stompHandler = onMessage;
+  }
+}));
+
+test('stores sensor data per device', () => {
+  const { result } = renderHook(() => useLiveDevices([SENSOR_TOPIC], 'S01'));
+
+  act(() => {
+    global.__stompHandler(SENSOR_TOPIC, {
+      deviceId: 'G01',
+      system: 'S01',
+      sensors: [
+        { type: 'temperature', value: '20' },
+        { type: 'humidity', value: '50' }
+      ]
+    });
+  });
+
+  act(() => {
+    global.__stompHandler(SENSOR_TOPIC, {
+      deviceId: 'G02',
+      system: 'S01',
+      sensors: [
+        { type: 'temperature', value: '21' },
+        { type: 'humidity', value: '55' }
+      ]
+    });
+  });
+
+  expect(result.current.sensorData['G01'].temperature.value).toBe(20);
+  expect(result.current.sensorData['G02'].humidity.value).toBe(55);
+});


### PR DESCRIPTION
## Summary
- Track sensor readings per device in `useLiveDevices`
- Use selected device's readings in `SensorDashboard`'s SpectrumBarChart
- Add unit test for per-device sensor data

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_6896fef9474083288ada33498dd3af50