### PR TITLE
Handle AS7343 spectrum channels

### DIFF
--- a/src/components/SpectrumBarChart.jsx
+++ b/src/components/SpectrumBarChart.jsx
@@ -7,7 +7,7 @@ import idealRanges from '../idealRangeConfig';
 import palette from '../colorPalette';
 import spectralColors from '../spectralColors';
 
-const bandMeta = [
+const legacyBandMeta = [
     ['F1', 'F1 (400–430 nm)'],
     ['F2', 'F2 (430–460 nm)'],
     ['F3', 'F3 (460–500 nm)'],
@@ -20,7 +20,7 @@ const bandMeta = [
     ['nir', 'Near infrared'],
 ];
 
-const bandMap = {
+const legacyBandMap = {
     F1: '415nm',
     F2: '445nm',
     F3: '480nm',
@@ -31,23 +31,52 @@ const bandMap = {
     F8: '680nm',
 };
 
+const as7343BandMeta = [
+    ['405nm', '405 nm'],
+    ['425nm', '425 nm'],
+    ['450nm', '450 nm'],
+    ['475nm', '475 nm'],
+    ['515nm', '515 nm'],
+    ['550nm', '550 nm'],
+    ['555nm', '555 nm'],
+    ['600nm', '600 nm'],
+    ['640nm', '640 nm'],
+    ['690nm', '690 nm'],
+    ['745nm', '745 nm'],
+    ['VIS1', 'VIS1'],
+    ['VIS2', 'VIS2'],
+    ['NIR855', 'NIR855'],
+];
+
 function SpectrumBarChart({ sensorData }) {
     console.log('3- SPECTRUM DATA', sensorData);
+
+    const { bandMeta, bandMap } = useMemo(() => {
+        if (!sensorData) {
+            return { bandMeta: legacyBandMeta, bandMap: legacyBandMap };
+        }
+        const keys = Object.keys(sensorData);
+        const hasAs7343 = as7343BandMeta.some(([k]) => keys.includes(k));
+        return hasAs7343
+            ? { bandMeta: as7343BandMeta, bandMap: {} }
+            : { bandMeta: legacyBandMeta, bandMap: legacyBandMap };
+    }, [sensorData]);
+
     const data = useMemo(() => {
-    if (!sensorData) return [];
-    return bandMeta.map(([key, label], index) => {
-                const rangeKey = bandMap[key] || key;
-                const range = idealRanges[rangeKey]?.idealRange;
-                return {
-                    key,
-                    index,
-                    name: label,
-                    value: sensorData[key] || 0,
-                    min: range?.min,
-                    max: range?.max,
-                };
-    });
-}, [sensorData]);
+        if (!sensorData) return [];
+        return bandMeta.map(([key, label], index) => {
+            const rangeKey = bandMap[key] || key;
+            const range = idealRanges[rangeKey]?.idealRange;
+            return {
+                key,
+                index,
+                name: label,
+                value: sensorData[key] || 0,
+                min: range?.min,
+                max: range?.max,
+            };
+        });
+    }, [sensorData, bandMeta, bandMap]);
 
 
     return (

--- a/src/utils.js
+++ b/src/utils.js
@@ -63,7 +63,7 @@ export function normalizeSensorData(data) {
                 }
 
                 default: {
-                    // Map nm wavelengths or clear/nir
+                    // Map nm wavelengths or additional spectral keys
                     const nmMatch = type?.match(/^(\d{3})nm$/);
                     if (nmMatch) {
                         const nmMap = {
@@ -71,8 +71,14 @@ export function normalizeSensorData(data) {
                             '555': 'F5', '590': 'F6', '630': 'F7', '680': 'F8',
                         };
                         const band = nmMap[nmMatch[1]];
-                        if (band) result[band] = val;
-                    } else if (type === 'clear' || type === 'nir') {
+                        if (band) {
+                            result[band] = val;
+                        } else {
+                            // Keep the raw wavelength key if not mapped
+                            result[`${nmMatch[1]}nm`] = val;
+                        }
+                    } else if (type === 'clear' || type === 'nir' ||
+                        type === 'VIS1' || type === 'VIS2' || type === 'NIR855') {
                         result[type] = val;
                     }
                     break;
@@ -113,6 +119,10 @@ export function transformAggregatedData(data) {
                     timestamp: ts,
                     F1: 0, F2: 0, F3: 0, F4: 0, F5: 0,
                     F6: 0, F7: 0, F8: 0, clear: 0, nir: 0,
+                    '405nm': 0, '425nm': 0, '450nm': 0, '475nm': 0,
+                    '515nm': 0, '550nm': 0, '555nm': 0, '600nm': 0,
+                    '640nm': 0, '690nm': 0, '745nm': 0,
+                    VIS1: 0, VIS2: 0, NIR855: 0,
                     temperature: {value: 0, unit: '°C'},
                     humidity: {value: 0, unit: '%'},
                     lux: {value: 0, unit: 'lux'},
@@ -183,6 +193,42 @@ export function transformAggregatedData(data) {
                     break;
                 case '680nm':
                     out.F8 = Number(val);
+                    break;
+                case '405nm':
+                    out['405nm'] = Number(val);
+                    break;
+                case '425nm':
+                    out['425nm'] = Number(val);
+                    break;
+                case '450nm':
+                    out['450nm'] = Number(val);
+                    break;
+                case '475nm':
+                    out['475nm'] = Number(val);
+                    break;
+                case '550nm':
+                    out['550nm'] = Number(val);
+                    break;
+                case '600nm':
+                    out['600nm'] = Number(val);
+                    break;
+                case '640nm':
+                    out['640nm'] = Number(val);
+                    break;
+                case '690nm':
+                    out['690nm'] = Number(val);
+                    break;
+                case '745nm':
+                    out['745nm'] = Number(val);
+                    break;
+                case 'VIS1':
+                    out.VIS1 = Number(val);
+                    break;
+                case 'VIS2':
+                    out.VIS2 = Number(val);
+                    break;
+                case 'NIR855':
+                    out.NIR855 = Number(val);
                     break;
                 case 'clear':
                     out.clear = Number(val);

--- a/tests/SpectrumBarChart.test.jsx
+++ b/tests/SpectrumBarChart.test.jsx
@@ -38,3 +38,20 @@ test('renders spectrum bar chart', () => {
 
   expect(container.firstChild).toBeInTheDocument();
 });
+
+test('renders spectrum bar chart for as7343 data', () => {
+    const data = {
+        '405nm': 1, '425nm': 2, '450nm': 3, '475nm': 4,
+        '515nm': 5, '550nm': 6, '555nm': 7, '600nm': 8,
+        '640nm': 9, '690nm': 10, '745nm': 11,
+        VIS1: 12, VIS2: 13, NIR855: 14,
+    };
+
+    const { container } = render(
+        <div style={{ width: 800, height: 400 }}>
+            <SpectrumBarChart sensorData={data} />
+        </div>
+    );
+
+    expect(container.firstChild).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- support AS7343 sensor wavelengths in normalization and history transforms
- auto-detect spectrum bands and render dynamically in SpectrumBarChart
- add test coverage for AS7343 spectrum data

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68970287ce808328b07e1903eda30651