### PR TITLE
Add topic filtering and fix device headers

### DIFF
--- a/src/components/DeviceTable.jsx
+++ b/src/components/DeviceTable.jsx
@@ -85,8 +85,8 @@ function DeviceTable({devices = {}}) {
                     {deviceIds.map(id => {
                         const dev = devices[id];
                         const loc = dev?.location ?? dev?.Location ?? dev?.meta?.location ?? "";
-                        const label = loc ? `${loc}${id}` : id;
-                        console.log("device:", devices[id]);
+                        const baseId = dev?.deviceId || id;
+                        const label = loc ? `${loc}${baseId}` : baseId;
                         return <th key={id}>{label}</th>;
                     })}
                 </tr>

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -5,8 +5,8 @@ import {useFilters, ALL} from "../context/FiltersContext";
 
 export default function Sidebar() {
     const [collapsed, setCollapsed] = useState(false);
-    const [open, setOpen] = useState({device: false, layer: false, system: false});
-    const {device, layer, system, setDevice, setLayer, setSystem, lists} = useFilters();
+    const [open, setOpen] = useState({topic: false, device: false, layer: false, system: false});
+    const {device, layer, system, topic, setDevice, setLayer, setSystem, setTopic, lists} = useFilters();
 
     const linkClass = ({isActive}) =>
         `${styles.menuItem} ${isActive ? styles.active : ""}`;
@@ -86,6 +86,8 @@ export default function Sidebar() {
             <section className={styles.filters}>
                 {!collapsed && <div className={styles.filtersTitle}>Application filters</div>}
 
+                <Row k="topic" title={`Topic${topic !== ALL ? `: ${topic}` : ""}`}
+                     list={lists.topics} value={topic} onChange={setTopic}/>
                 <Row k="device" title={`Device${device !== ALL ? `: ${device}` : ""}`}
                      list={lists.devices} value={device} onChange={setDevice}/>
                 <Row k="layer" title={`Layer${layer !== ALL ? `: ${layer}` : ""}`}

--- a/src/components/dashboard/useLiveDevices.js
+++ b/src/components/dashboard/useLiveDevices.js
@@ -43,14 +43,17 @@ export function useLiveDevices(topics, activeSystem) {
 
     useStomp(topics, handleStompMessage);
 
-    const sensorTopicDevices = (deviceData[activeSystem] || {})[SENSOR_TOPIC] || {};
+    const sysData = deviceData[activeSystem] || {};
 
     const availableBaseIds = useMemo(() => {
-        const ids = new Set(
-            Object.values(sensorTopicDevices).map(d => d?.deviceId || "unknown")
-        );
+        const ids = new Set();
+        for (const topicDevices of Object.values(sysData)) {
+            for (const d of Object.values(topicDevices)) {
+                ids.add(d?.deviceId || "unknown");
+            }
+        }
         return Array.from(ids);
-    }, [sensorTopicDevices]);
+    }, [sysData]);
 
     const mergedDevices = useMemo(() => {
         const sysData = deviceData[activeSystem] || {};

--- a/src/context/FiltersContext.jsx
+++ b/src/context/FiltersContext.jsx
@@ -9,18 +9,20 @@ export function FiltersProvider({ children, initialLists }) {
     const [device, setDevice] = useState(ALL);
     const [layer, setLayer]   = useState(ALL);
     const [system, setSystem] = useState(ALL);
+    const [topic, setTopic] = useState(ALL);
 
     const [lists, setLists] = useState({
         devices: initialLists?.devices ?? [],
         layers:  initialLists?.layers ?? [],
         systems: initialLists?.systems ?? [],
+        topics:  initialLists?.topics ?? [],
     });
 
     const value = useMemo(() => ({
-    ALL, device, layer, system,
-    setDevice, setLayer, setSystem,
+    ALL, device, layer, system, topic,
+    setDevice, setLayer, setSystem, setTopic,
     lists, setLists,
-    }), [device, layer, system, lists]);
+    }), [device, layer, system, topic, lists]);
 
   return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
 }


### PR DESCRIPTION
## Summary
- add topic state to filters context and expose topic list in sidebar
- include all topics when computing live device IDs
- clean up device table headers to avoid duplicate locations

## Testing
- `npm test -- --run`
- `npm run lint` (warnings only)


------
https://chatgpt.com/codex/tasks/task_e_689718ddec308328b95a2509a5ded0a6