### PR TITLE
Handle device health keys case-insensitively

### DIFF
--- a/src/components/DeviceTable.jsx
+++ b/src/components/DeviceTable.jsx
@@ -65,7 +65,9 @@ function DeviceTable({devices = {}}) {
             const value = s?.value;
             const unit = s?.unit || '';
             const display = (value === undefined || value === null) ? '-' : `${typeof value === 'number' ? value.toFixed(1) : value}${unit ? ` ${unit}` : ''}`;
-            const ok = devices[id].health?.[s?.sensorName] ?? false;
+            const health = devices[id].health || {};
+            const sensorKey = s?.sensorName?.toLowerCase();
+            const ok = health[sensorKey] ?? health[s?.sensorName] ?? false;
             const color = getCellColor(value, range);
             return {display, ok, color};
         });

--- a/src/utils.js
+++ b/src/utils.js
@@ -16,7 +16,7 @@ export function filterNoise(data) {
 function normalizeHealth(health = {}) {
     const normalized = {};
     for (const key in health) {
-        const base = key.split('-')[0];
+        const base = key.split('-')[0].toLowerCase();
         normalized[base] = health[key] === true || health[key] === 'true' || health[key] === 1;
     }
     return normalized;

--- a/tests/DeviceTable.test.jsx
+++ b/tests/DeviceTable.test.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import DeviceTable from '../src/components/DeviceTable';
+import styles from '../src/components/DeviceTable.module.css';
 
 const devices = {
   dev1: {
@@ -56,4 +57,18 @@ test('applies spectral background color to 415nm row', () => {
   const { getByText } = render(<DeviceTable devices={devices} />);
   const spectralCell = getByText('415nm');
   expect(spectralCell).toHaveStyle({ backgroundColor: '#8a2be222' });
+});
+
+test('shows green indicator when health keys are lowercase', () => {
+  const devicesLower = {
+    dev1: {
+      sensors: [
+        { sensorName: 'SHT3x', valueType: 'temperature', value: 22.5, unit: '°C' }
+      ],
+      health: { sht3x: true }
+    }
+  };
+  const { container } = render(<DeviceTable devices={devicesLower} />);
+  const indicator = container.querySelector(`.${styles.indicator}`);
+  expect(indicator).toHaveClass(styles.on);
 });


### PR DESCRIPTION
## Summary
- Normalize health keys to lowercase
- Treat health map lookups in DeviceTable without case sensitivity
- Add regression test for lowercase health keys

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897351e2e54832889a6344f446d88a7