### PR TITLE
Fix report tab detection for sensor names

### DIFF
--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -141,7 +141,7 @@ function SensorDashboard() {
             (d) => d?.deviceId === selectedDevice
         );
         const sensors = match?.sensors || [];
-        return sensors.map((s) => s.type || s.valueType);
+        return sensors.map((s) => (s.type || s.valueType || '').toLowerCase());
     }, [sensorTopicDevices, selectedDevice]);
 
     const sensorNamesForSelected = useMemo(() => {
@@ -149,7 +149,7 @@ function SensorDashboard() {
             (d) => d?.deviceId === selectedDevice
         );
         const sensors = match?.sensors || [];
-        return sensors.map((s) => s.sensorName || s.source || "-");
+        return sensors.map((s) => (s.sensorName || s.source || '-').toLowerCase());
     }, [sensorTopicDevices, selectedDevice]);
 
     const showTempHum = sensorNamesForSelected.includes("sht3x");
@@ -169,7 +169,7 @@ function SensorDashboard() {
         sensorTypesForSelected.includes("tds");
     const showDo =
         sensorTypesForSelected.includes("do") ||
-        sensorTypesForSelected.includes("dissolvedOxygen");
+        sensorTypesForSelected.includes("dissolvedoxygen");
     const showAnyReport = showTempHum || showSpectrum || showClearLux || showPh || showEcTds || showDo;
 
 

--- a/tests/SensorDashboard.test.jsx
+++ b/tests/SensorDashboard.test.jsx
@@ -15,8 +15,8 @@ vi.mock('../src/components/dashboard/useLiveDevices', () => ({
           G01: {
             deviceId: 'G01',
             sensors: [
-              { sensorName: 'as7343' },
-              { sensorName: 'sht3x' },
+              { sensorName: 'AS7343' },
+              { sensorName: 'SHT3x' },
             ],
           },
         },
@@ -65,7 +65,7 @@ vi.mock('../src/components/dashboard/VerticalTabs', () => ({
   ),
 }));
 
-test('shows charts for AS7343 and SHT31 sensors', () => {
+test('shows charts for AS7343 and SHT3x sensors (case-insensitive)', () => {
   render(<SensorDashboard />);
   // Switch to report tab
   fireEvent.click(screen.getByText('to-report'));


### PR DESCRIPTION
## Summary
- Normalize sensor names and types to lowercase so report tab recognizes sensors regardless of casing
- Update tests to cover uppercase sensor names

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689747703ea48328bb51fc8bb73edc75