### PR TITLE
Add checkbox filters to historical charts

### DIFF
--- a/src/components/HistoricalEcTdsChart.jsx
+++ b/src/components/HistoricalEcTdsChart.jsx
@@ -36,6 +36,8 @@ const HistoricalEcTdsChart = ({
             : `${d.getMonth() + 1}/${d.getDate()}`;
     };
 
+    const [selectedKeys, setSelectedKeys] = React.useState(['tds', 'ec']);
+
     const ecRange = idealRanges.ec?.idealRange;
     const tdsRange = idealRanges.tds?.idealRange;
 
@@ -65,75 +67,114 @@ const HistoricalEcTdsChart = ({
         return [min, max];
     }, [data, tdsRange]);
 
+    const toggleKey = (key) => {
+        setSelectedKeys(prev =>
+            prev.includes(key) ? prev.filter(k => k !== key) : [...prev, key]
+        );
+    };
+
+    const allSelected = selectedKeys.length === 2;
+    const toggleAll = () => {
+        setSelectedKeys(allSelected ? [] : ['tds', 'ec']);
+    };
+
     return (
-        <ResponsiveContainer width="100%" height={height} debounce={200}>
-            <LineChart
-                width={width}
-                height={height}
-                data={data}
-                margin={{ top: 20, right: 30, left: 0, bottom: 50 }}
-                isAnimationActive={false}
-            >
-                <CartesianGrid strokeDasharray="3 3" />
-                <XAxis
-                    dataKey="time"
-                    type="number"
-                    domain={xDomain}
-                    ticks={ticks}
-                    tickFormatter={tickFormatter}
-                    scale="time"
-                    tick={{ fontSize: 10 }}
-                />
-                <YAxis yAxisId="left" domain={tdsDomain} allowDataOverflow>
-                    <Label value="TDS (ppm)" angle={-90} position="insideLeft" style={{ textAnchor: 'middle' }} />
-                </YAxis>
-                <YAxis yAxisId="right" orientation="right" domain={ecDomain} allowDataOverflow>
-                    <Label value="EC (mS/cm)" angle={-90} position="insideRight" style={{ textAnchor: 'middle' }} />
-                </YAxis>
-                {tdsRange && (
-                    <ReferenceArea
-                        yAxisId="left"
-                        y1={tdsRange.min}
-                        y2={tdsRange.max}
-                        x1={start}
-                        x2={end}
-                        fill={palette[0]}
-                        fillOpacity={0.1}
-                        stroke="none"
-                    />
-                )}
-                {ecRange && (
-                    <ReferenceArea
-                        yAxisId="right"
-                        y1={ecRange.min}
-                        y2={ecRange.max}
-                        x1={start}
-                        x2={end}
-                        fill={palette[5]}
-                        fillOpacity={0.1}
-                        stroke="none"
-                    />
-                )}
-                <Tooltip />
-                <Legend />
-                <Line
-                    yAxisId="left"
-                    type="monotone"
-                    dataKey="tds"
-                    stroke={palette[0]}
-                    dot={false}
+        <div>
+            <ResponsiveContainer width="100%" height={height} debounce={200}>
+                <LineChart
+                    width={width}
+                    height={height}
+                    data={data}
+                    margin={{ top: 20, right: 30, left: 0, bottom: 50 }}
                     isAnimationActive={false}
-                />
-                <Line
-                    yAxisId="right"
-                    type="monotone"
-                    dataKey="ec"
-                    stroke={palette[5]}
-                    dot={false}
-                    isAnimationActive={false}
-                />
-            </LineChart>
-        </ResponsiveContainer>
+                >
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis
+                        dataKey="time"
+                        type="number"
+                        domain={xDomain}
+                        ticks={ticks}
+                        tickFormatter={tickFormatter}
+                        scale="time"
+                        tick={{ fontSize: 10 }}
+                    />
+                    <YAxis yAxisId="left" domain={tdsDomain} allowDataOverflow>
+                        <Label value="TDS (ppm)" angle={-90} position="insideLeft" style={{ textAnchor: 'middle' }} />
+                    </YAxis>
+                    <YAxis yAxisId="right" orientation="right" domain={ecDomain} allowDataOverflow>
+                        <Label value="EC (mS/cm)" angle={-90} position="insideRight" style={{ textAnchor: 'middle' }} />
+                    </YAxis>
+                    {tdsRange && (
+                        <ReferenceArea
+                            yAxisId="left"
+                            y1={tdsRange.min}
+                            y2={tdsRange.max}
+                            x1={start}
+                            x2={end}
+                            fill={palette[0]}
+                            fillOpacity={0.1}
+                            stroke="none"
+                        />
+                    )}
+                    {ecRange && (
+                        <ReferenceArea
+                            yAxisId="right"
+                            y1={ecRange.min}
+                            y2={ecRange.max}
+                            x1={start}
+                            x2={end}
+                            fill={palette[5]}
+                            fillOpacity={0.1}
+                            stroke="none"
+                        />
+                    )}
+                    <Tooltip />
+                    <Legend />
+                    {selectedKeys.includes('tds') && (
+                        <Line
+                            yAxisId="left"
+                            type="monotone"
+                            dataKey="tds"
+                            stroke={palette[0]}
+                            dot={false}
+                            isAnimationActive={false}
+                        />
+                    )}
+                    {selectedKeys.includes('ec') && (
+                        <Line
+                            yAxisId="right"
+                            type="monotone"
+                            dataKey="ec"
+                            stroke={palette[5]}
+                            dot={false}
+                            isAnimationActive={false}
+                        />
+                    )}
+                </LineChart>
+            </ResponsiveContainer>
+            <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.5rem' }}>
+                <label style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+                    <input
+                        type="checkbox"
+                        checked={selectedKeys.includes('tds')}
+                        onChange={() => toggleKey('tds')}
+                    />
+                    TDS
+                </label>
+                <label style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+                    <input
+                        type="checkbox"
+                        checked={selectedKeys.includes('ec')}
+                        onChange={() => toggleKey('ec')}
+                    />
+                    EC
+                </label>
+                <label style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+                    <input type="checkbox" checked={allSelected} onChange={toggleAll} />
+                    All
+                </label>
+            </div>
+        </div>
     );
 };
 

--- a/tests/HistoricalEcTdsChart.test.jsx
+++ b/tests/HistoricalEcTdsChart.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import HistoricalEcTdsChart from '../src/components/HistoricalEcTdsChart';
 import { vi } from 'vitest';
@@ -37,6 +37,17 @@ describe('HistoricalEcTdsChart', () => {
     const { container } = render(<HistoricalEcTdsChart data={mockData} />);
     const rechartsWrapper = container.querySelector('.recharts-responsive-container');
     expect(rechartsWrapper).toBeTruthy();
+  });
+
+  it('toggles lines using checkboxes', () => {
+    const { getByLabelText } = render(<HistoricalEcTdsChart data={mockData} />);
+    const tdsCb = getByLabelText('TDS');
+    const allCb = getByLabelText('All');
+    expect(tdsCb).toBeChecked();
+    fireEvent.click(tdsCb);
+    expect(tdsCb).not.toBeChecked();
+    fireEvent.click(allCb);
+    expect(tdsCb).toBeChecked();
   });
 });
 

--- a/tests/HistoricalMultiBandChart.test.jsx
+++ b/tests/HistoricalMultiBandChart.test.jsx
@@ -1,7 +1,19 @@
 import React from 'react';
 import { describe, it, expect } from 'vitest';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import HistoricalMultiBandChart from '../src/components/HistoricalMultiBandChart';
+
+beforeAll(() => {
+  Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+    configurable: true,
+    value: 600,
+  });
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+    configurable: true,
+    value: 300,
+  });
+});
 
 describe('HistoricalMultiBandChart', () => {
   const now = Date.now();
@@ -28,13 +40,21 @@ describe('HistoricalMultiBandChart', () => {
     },
   ];
 
-  it('renders without crashing', () => {
-    const { container } = render(
+  it('renders checkboxes to toggle bands', () => {
+    const { container, getByLabelText } = render(
       <HistoricalMultiBandChart
         data={mockData}
         bandKeys={['405nm', '425nm', 'F4', '555nm', 'VIS1', 'VIS2', 'NIR855']}
       />
     );
-    expect(container).toBeTruthy();
+    const cb405 = getByLabelText('405nm');
+    expect(cb405).toBeInTheDocument();
+    const cbAll = getByLabelText('All');
+    expect(cbAll).toBeInTheDocument();
+    expect(cb405).toBeChecked();
+    fireEvent.click(cb405);
+    expect(cb405).not.toBeChecked();
+    fireEvent.click(cbAll);
+    expect(cb405).toBeChecked();
   });
 });


### PR DESCRIPTION
## Summary
- add selectable band checkboxes to HistoricalMultiBandChart
- allow toggling EC and TDS lines via checkboxes in HistoricalEcTdsChart
- cover new checkbox behavior with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897502cd4ec8328b9c76bffe9c95adf