### PR TITLE
Switch sidebar filters to checkbox lists

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,47 +1,42 @@
-import React, {useState} from "react";
-import {NavLink} from "react-router-dom";
+import React, { useState } from "react";
+import { NavLink } from "react-router-dom";
 import styles from "./Sidebar.module.css";
-import {useFilters, ALL} from "../context/FiltersContext";
+import { useFilters, ALL } from "../context/FiltersContext";
 
 export default function Sidebar() {
     const [collapsed, setCollapsed] = useState(false);
-    const [open, setOpen] = useState({topic: false, device: false, layer: false, system: false});
-    const {device, layer, system, topic, setDevice, setLayer, setSystem, setTopic, lists} = useFilters();
+    const { device, layer, system, topic, setDevice, setLayer, setSystem, setTopic, lists } = useFilters();
 
-    const linkClass = ({isActive}) =>
+    const linkClass = ({ isActive }) =>
         `${styles.menuItem} ${isActive ? styles.active : ""}`;
 
-    const caret = (isOpen) => (
-        <span className={`${styles.caret} ${isOpen ? styles.up : ""}`}/>
-    );
-
-    const Row = ({k, title, list, value, onChange}) => (
+    const CheckboxGroup = ({ title, list, value, onChange }) => (
         <div className={styles.filterGroup}>
-            <button
-                type="button"
-                className={styles.filterRow}
-                onClick={() => setOpen(o => ({...o, [k]: !o[k]}))}
-            >
-                {!collapsed && <span className={styles.filterLabel}>{title}</span>}
-                {caret(open[k])}
-            </button>
+            {!collapsed && <div className={styles.filterLabel}>{title}</div>}
 
-            {open[k] && !collapsed && (
+            {!collapsed && (
                 <div className={styles.dropdown}>
-                    <button
-                        className={`${styles.option} ${value === ALL ? styles.selected : ""}`}
-                        onClick={() => onChange(ALL)}
-                    >All
-                    </button>
+                    <label className={`${styles.option} ${value === ALL ? styles.selected : ""}`}>
+                        <input
+                            type="checkbox"
+                            checked={value === ALL}
+                            onChange={() => onChange(ALL)}
+                        />
+                        All
+                    </label>
 
-                    {list.map(item => (
-                        <button
+                    {list.map((item) => (
+                        <label
                             key={item}
                             className={`${styles.option} ${value === item ? styles.selected : ""}`}
-                            onClick={() => onChange(item)}
                         >
+                            <input
+                                type="checkbox"
+                                checked={value === item}
+                                onChange={() => onChange(value === item ? ALL : item)}
+                            />
                             {item}
-                        </button>
+                        </label>
                     ))}
                 </div>
             )}
@@ -86,14 +81,10 @@ export default function Sidebar() {
             <section className={styles.filters}>
                 {!collapsed && <div className={styles.filtersTitle}>Application filters</div>}
 
-                <Row k="topic" title={`Topic${topic !== ALL ? `: ${topic}` : ""}`}
-                     list={lists.topics} value={topic} onChange={setTopic}/>
-                <Row k="device" title={`Device${device !== ALL ? `: ${device}` : ""}`}
-                     list={lists.devices} value={device} onChange={setDevice}/>
-                <Row k="layer" title={`Layer${layer !== ALL ? `: ${layer}` : ""}`}
-                     list={lists.layers} value={layer} onChange={setLayer}/>
-                <Row k="system" title={`System${system !== ALL ? `: ${system}` : ""}`}
-                     list={lists.systems} value={system} onChange={setSystem}/>
+                <CheckboxGroup title="Topic" list={lists.topics} value={topic} onChange={setTopic} />
+                <CheckboxGroup title="Device" list={lists.devices} value={device} onChange={setDevice} />
+                <CheckboxGroup title="Layer" list={lists.layers} value={layer} onChange={setLayer} />
+                <CheckboxGroup title="System" list={lists.systems} value={system} onChange={setSystem} />
             </section>
         </aside>
     );

--- a/src/components/Sidebar.module.css
+++ b/src/components/Sidebar.module.css
@@ -22,14 +22,11 @@
 .filters { padding:6px 8px 14px; display:flex; flex-direction:column; gap:10px; }
 .filtersTitle { font-size:12px; color:#9ab0ce; margin:4px 6px; user-select:none; }
 .filterGroup { display:flex; flex-direction:column; gap:6px; }
-.filterRow { display:flex; align-items:center; justify-content:space-between; background:rgba(255,255,255,.04); border:1px solid #24324a; border-radius:8px; padding:9px 12px; color:#e8edf6; cursor:pointer; }
-.caret { width:0; height:0; border-left:6px solid transparent; border-right:6px solid transparent; border-top:7px solid #90a4c7; transition: transform .2s; }
-.up { transform: rotate(180deg); }
 .dropdown { display:flex; flex-direction:column; background:#0f1a2b; border:1px solid #24324a; border-radius:8px; overflow:hidden; }
-.option { text-align:left; padding:8px 12px; color:#e8edf6; background:transparent; border:0; cursor:pointer; }
+.option { text-align:left; padding:8px 12px; color:#e8edf6; background:transparent; border:0; cursor:pointer; display:flex; align-items:center; gap:8px; }
 .option:hover { background:#1c2a40; }
 .selected { background:#1c2a40; }
 
 /* collapsed */
 .collapsed .brand, .collapsed .text, .collapsed .filtersTitle { display:none; }
-.collapsed .menuItem, .collapsed .filterRow { justify-content:center; padding:10px; }
+.collapsed .menuItem { justify-content:center; padding:10px; }


### PR DESCRIPTION
## Summary
- Replace collapsible filter dropdowns with always-visible checkbox groups in the sidebar
- Style checkbox options for the new always-open layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68976b58183c8328892e4c9cc886a432