### PR TITLE
Use composite IDs for live spectrum

### DIFF
--- a/src/components/dashboard/ReportControls.jsx
+++ b/src/components/dashboard/ReportControls.jsx
@@ -9,7 +9,7 @@ function ReportControls({
   onNow,
   onApply,
   selectedDevice,
-  availableBaseIds = [],
+  availableCompositeIds = [],
   onDeviceChange,
   autoRefresh,
   onAutoRefreshChange,
@@ -42,7 +42,7 @@ function ReportControls({
         <label className={styles.filterLabel}>
           Device:
           <select className={styles.intervalSelect} value={selectedDevice} onChange={onDeviceChange}>
-            {availableBaseIds.map((id) => (
+            {availableCompositeIds.map((id) => (
               <option key={id} value={id}>
                 {id}
               </option>

--- a/src/components/dashboard/useLiveDevices.js
+++ b/src/components/dashboard/useLiveDevices.js
@@ -22,7 +22,7 @@ export function useLiveDevices(topics, activeSystem) {
             const normalized = normalizeSensorData(payload);
             const cleaned = topic === SENSOR_TOPIC ? filterNoise(normalized) : normalized;
             if (cleaned && topic === SENSOR_TOPIC) {
-                setSensorData(prev => ({...prev, [baseId]: cleaned}));
+                setSensorData(prev => ({...prev, [compositeId]: cleaned}));
             }
         }
 
@@ -30,7 +30,8 @@ export function useLiveDevices(topics, activeSystem) {
             sensors: Array.isArray(payload.sensors) ? payload.sensors : [],
             health: payload.health || {},
             ...(loc ? {location: loc} : {}),
-            deviceId: baseId
+            deviceId: baseId,
+            compositeId
         };
 
         setDeviceData(prev => {
@@ -43,12 +44,12 @@ export function useLiveDevices(topics, activeSystem) {
 
     useStomp(topics, handleStompMessage);
 
-    const availableBaseIds = useMemo(() => {
+    const availableCompositeIds = useMemo(() => {
         const sysData = deviceData[activeSystem] || {};
         const ids = new Set();
         for (const topicDevices of Object.values(sysData)) {
-            for (const d of Object.values(topicDevices)) {
-                ids.add(d?.deviceId || "unknown");
+            for (const cid of Object.keys(topicDevices)) {
+                ids.add(cid);
             }
         }
         return Array.from(ids);
@@ -65,6 +66,6 @@ export function useLiveDevices(topics, activeSystem) {
         return combined;
     }, [deviceData, activeSystem]);
 
-    return {deviceData, sensorData, availableBaseIds, mergedDevices};
+    return {deviceData, sensorData, availableCompositeIds, mergedDevices};
 }
 

--- a/tests/SensorDashboard.test.jsx
+++ b/tests/SensorDashboard.test.jsx
@@ -12,8 +12,9 @@ vi.mock('../src/components/dashboard/useLiveDevices', () => ({
     deviceData: {
       S01: {
         growSensors: {
-          G01: {
+          L01G01: {
             deviceId: 'G01',
+            location: 'L01',
             sensors: [
               { sensorName: 'AS7343' },
               { sensorName: 'SHT3x' },
@@ -23,7 +24,7 @@ vi.mock('../src/components/dashboard/useLiveDevices', () => ({
       },
     },
     sensorData: {},
-    availableBaseIds: ['G01'],
+    availableCompositeIds: ['L01G01'],
     mergedDevices: {},
   }),
 }));

--- a/tests/useLiveDevices.test.jsx
+++ b/tests/useLiveDevices.test.jsx
@@ -10,12 +10,13 @@ vi.mock('../src/hooks/useStomp', () => ({
   }
 }));
 
-test('stores sensor data per device', () => {
+test('stores sensor data per composite device', () => {
   const { result } = renderHook(() => useLiveDevices([SENSOR_TOPIC], 'S01'));
 
   act(() => {
     global.__stompHandler(SENSOR_TOPIC, {
       deviceId: 'G01',
+      location: 'L01',
       system: 'S01',
       sensors: [
         { type: 'temperature', value: '20' },
@@ -35,6 +36,6 @@ test('stores sensor data per device', () => {
     });
   });
 
-  expect(result.current.sensorData['G01'].temperature.value).toBe(20);
+  expect(result.current.sensorData['L01G01'].temperature.value).toBe(20);
   expect(result.current.sensorData['G02'].humidity.value).toBe(55);
 });


### PR DESCRIPTION
## Summary
- Track live sensor data by `compositeId` and expose `availableCompositeIds`
- Update dashboard and report controls to select devices by composite ID
- Adjust unit tests for composite ID behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898420e161c832899f59b56d271b4d2