### PR TITLE
Make report charts wider

### DIFF
--- a/src/components/SensorDashboard.module.css
+++ b/src/components/SensorDashboard.module.css
@@ -204,10 +204,11 @@
 
 @media (min-width: 768px) {
     .historyChartsRow {
-        flex-direction: row;
+        flex-direction: column;
+        align-items: center;
     }
     .historyChartColumn {
-        width: 50%;
+        width: 90%;
     }
     .multiBandChartWrapper,
     .blueBandChartWrapper,


### PR DESCRIPTION
## Summary
- enlarge report charts to 90% width and center them

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68984615786c832898e7c0bd07895c29