### PR TITLE
Fix router base path for reports page

### DIFF
--- a/src/compat/react-router-dom.jsx
+++ b/src/compat/react-router-dom.jsx
@@ -1,24 +1,35 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 
-const RouterContext = createContext({ path: '/', navigate: () => {} });
+const RouterContext = createContext({ path: '/', navigate: () => {}, base: '' });
 const OutletContext = createContext(null);
 
+function stripBase(path, base) {
+    if (base && path.startsWith(base)) {
+        const stripped = path.slice(base.length);
+        return stripped.startsWith('/') ? stripped : '/' + stripped;
+    }
+    return path;
+}
+
 export function BrowserRouter({ children }) {
-    const [path, setPath] = useState(window.location.pathname || '/');
+    const base = (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.BASE_URL) || '/';
+    const baseNoSlash = base.endsWith('/') ? base.slice(0, -1) : base;
+
+    const [path, setPath] = useState(stripBase(window.location.pathname || '/', baseNoSlash));
 
     useEffect(() => {
-        const onPopState = () => setPath(window.location.pathname || '/');
+        const onPopState = () => setPath(stripBase(window.location.pathname || '/', baseNoSlash));
         window.addEventListener('popstate', onPopState);
         return () => window.removeEventListener('popstate', onPopState);
-    }, []);
+    }, [baseNoSlash]);
 
     const navigate = (to) => {
-        window.history.pushState({}, '', to);
+        window.history.pushState({}, '', `${baseNoSlash}${to}`);
         setPath(to);
     };
 
     return (
-        <RouterContext.Provider value={{ path, navigate }}>
+        <RouterContext.Provider value={{ path, navigate, base: baseNoSlash }}>
             {children}
         </RouterContext.Provider>
     );
@@ -73,12 +84,12 @@ export function Outlet() {
 }
 
 export function NavLink({ to, children, className }) {
-    const { path, navigate } = useContext(RouterContext);
+    const { path, navigate, base } = useContext(RouterContext);
     const isActive = path === to;
     const cls = typeof className === 'function' ? className({ isActive }) : className;
     return (
         <a
-            href={to}
+            href={`${base}${to}`}
             className={cls}
             onClick={(e) => {
                 e.preventDefault();

--- a/tests/AppReportsRoute.test.jsx
+++ b/tests/AppReportsRoute.test.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import '@testing-library/jest-dom';
+
+vi.mock('../src/components/dashboard/ReportControls', () => ({ default: () => <div>ReportControls</div> }));
+vi.mock('../src/components/Header', () => ({ default: () => <div>Header</div> }));
+vi.mock('../src/components/dashboard/ReportCharts', () => ({ default: () => <div>ReportCharts</div> }));
+vi.mock('../src/components/dashboard/useLiveDevices', () => ({
+  useLiveDevices: () => ({ deviceData: {}, availableCompositeIds: [] }),
+}));
+vi.mock('../src/components/dashboard/useHistory', () => ({
+  useHistory: () => ({}),
+}));
+vi.mock('../src/context/FiltersContext', () => ({
+  FiltersProvider: ({ children }) => <div>{children}</div>,
+  useFilters: () => ({
+    device: 'ALL',
+    layer: 'ALL',
+    system: 'ALL',
+    topic: 'ALL',
+    setLists: () => {},
+    lists: { topics: [], devices: [], layers: [], systems: [] },
+  }),
+  ALL: 'ALL',
+}));
+
+import App from '../src/App';
+
+test('reports link retains base path and is active when served from subdirectory', () => {
+  vi.stubEnv('BASE_URL', '/NFTMonitoring/');
+  window.history.pushState({}, '', '/NFTMonitoring/reports');
+  render(<App />);
+  const link = screen.getByRole('link', { name: /reports/i });
+  expect(link).toHaveAttribute('href', '/NFTMonitoring/reports');
+  expect(link.className).toMatch(/active/);
+});


### PR DESCRIPTION
## Summary
- normalize router paths relative to deployment base URL so subdirectory routes render
- ensure navigation links include base path
- add test covering routing with BASE_URL

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68986dc7774883289a68fe0d7471cac3