### PR TITLE
Normalize Vite base URL for router

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,7 +12,8 @@ import Layer from './pages/filters/Layer';
 import System from './pages/filters/System';
 
 function App() {
-    const base = import.meta?.env?.BASE_URL || '/';
+    const rawBase = import.meta?.env?.BASE_URL || '/';
+    const base = rawBase === './' || rawBase === '/./' ? '/' : rawBase;
 
     return (
         <BrowserRouter basename={base}>


### PR DESCRIPTION
## Summary
- sanitize Vite's BASE_URL before passing to BrowserRouter to avoid `/./` basename

## Testing
- `npm test -- --run` *(fails: WebSocket error Event { isTrusted: [Getter] })*

------
https://chatgpt.com/codex/tasks/task_e_6898acb2895c8328920230255a0d74a4