### PR TITLE
feat: add live_now websocket hook

### DIFF
--- a/src/hooks/useLiveNow.js
+++ b/src/hooks/useLiveNow.js
@@ -1,0 +1,48 @@
+import { useCallback, useState } from "react";
+import { useStomp } from "./useStomp";
+
+const DEFAULT_STATS = {
+  lux: { average: null, deviceCount: 0 },
+  humidity: { average: null, deviceCount: 0 },
+  temperature: { average: null, deviceCount: 0 },
+  do: { average: null, deviceCount: 0 },
+  airpump: { average: null, deviceCount: 0 },
+};
+
+export function useLiveNow() {
+  const [stats, setStats] = useState(DEFAULT_STATS);
+
+  const handleMessage = useCallback((_topic, msg) => {
+    if (msg && typeof msg === "object") {
+      setStats({
+        lux: {
+          average: msg?.lux?.average ?? null,
+          deviceCount: msg?.lux?.deviceCount ?? 0,
+        },
+        humidity: {
+          average: msg?.humidity?.average ?? null,
+          deviceCount: msg?.humidity?.deviceCount ?? 0,
+        },
+        temperature: {
+          average: msg?.temperature?.average ?? null,
+          deviceCount: msg?.temperature?.deviceCount ?? 0,
+        },
+        do: {
+          average: msg?.do?.average ?? null,
+          deviceCount: msg?.do?.deviceCount ?? 0,
+        },
+        airpump: {
+          average: msg?.airpump?.average ?? null,
+          deviceCount: msg?.airpump?.deviceCount ?? 0,
+        },
+      });
+    } else {
+      setStats(DEFAULT_STATS);
+    }
+  }, []);
+
+  useStomp("live_now", handleMessage);
+
+  return stats;
+}
+

--- a/tests/useLiveNow.test.jsx
+++ b/tests/useLiveNow.test.jsx
@@ -1,0 +1,35 @@
+import { renderHook, act } from '@testing-library/react';
+import { vi } from 'vitest';
+import { useLiveNow } from '../src/hooks/useLiveNow';
+
+vi.mock('../src/hooks/useStomp', () => ({
+  useStomp: (_topics, onMessage) => {
+    global.__liveNowHandler = onMessage;
+  }
+}));
+
+test('provides default stats and updates from websocket', () => {
+  const { result } = renderHook(() => useLiveNow());
+
+  expect(result.current).toEqual({
+    lux: { average: null, deviceCount: 0 },
+    humidity: { average: null, deviceCount: 0 },
+    temperature: { average: null, deviceCount: 0 },
+    do: { average: null, deviceCount: 0 },
+    airpump: { average: null, deviceCount: 0 }
+  });
+
+  act(() => {
+    global.__liveNowHandler('live_now', {
+      lux: { average: 100, deviceCount: 2 },
+      humidity: { average: 50, deviceCount: 2 },
+      temperature: { average: 20, deviceCount: 2 },
+      do: { average: 6.5, deviceCount: 1 },
+      airpump: { average: 1, deviceCount: 1 }
+    });
+  });
+
+  expect(result.current.lux.average).toBe(100);
+  expect(result.current.humidity.deviceCount).toBe(2);
+});
+


### PR DESCRIPTION
## Summary
- add `useLiveNow` hook to read live aggregate stats from `live_now` websocket topic
- test hook to ensure default payload and updates when messages arrive

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898df3921348328aa53df1a51ed49d6