### PR TITLE
feat: add live_now WebSocket topic hook

### DIFF
--- a/src/components/dashboard/dashboard.constants.js
+++ b/src/components/dashboard/dashboard.constants.js
@@ -1,5 +1,6 @@
 export const SENSOR_TOPIC = "growSensors";
-export const topics = [SENSOR_TOPIC, "rootImages", "waterOutput", "waterTank"];
+export const LIVE_NOW_TOPIC = "live_now";
+export const topics = [SENSOR_TOPIC, "rootImages", "waterOutput", "waterTank", LIVE_NOW_TOPIC];
 
 export const bandMap = {
   F1: "415nm",

--- a/src/hooks/useLiveNow.js
+++ b/src/hooks/useLiveNow.js
@@ -1,0 +1,16 @@
+import { useState, useCallback } from 'react';
+import { useStomp } from './useStomp';
+
+/**
+ * Subscribe to the `live_now` topic and expose the latest payload.
+ */
+export function useLiveNow() {
+    const [status, setStatus] = useState(null);
+
+    const handleMessage = useCallback((_topic, msg) => {
+        setStatus(msg);
+    }, []);
+
+    useStomp('live_now', handleMessage);
+    return status;
+}

--- a/tests/useLiveNow.test.jsx
+++ b/tests/useLiveNow.test.jsx
@@ -1,0 +1,20 @@
+import { renderHook, act } from '@testing-library/react';
+import { vi } from 'vitest';
+import { useLiveNow } from '../src/hooks/useLiveNow';
+
+// Mock useStomp to capture the message handler
+vi.mock('../src/hooks/useStomp', () => ({
+  useStomp: (_topics, onMessage) => {
+    global.__liveNowHandler = onMessage;
+  }
+}));
+
+test('captures live_now updates', () => {
+  const { result } = renderHook(() => useLiveNow());
+
+  act(() => {
+    global.__liveNowHandler('live_now', { ok: true });
+  });
+
+  expect(result.current).toEqual({ ok: true });
+});


### PR DESCRIPTION
## Summary
- add LIVE_NOW_TOPIC constant and include in subscribed topics
- create useLiveNow hook to read live_now topic
- test live_now hook

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68991fcf7508832893b978ee931de7b7