### PR TITLE
Use live_now topic for dashboard overview metrics

### DIFF
--- a/src/components/dashboard/dashboard.constants.js
+++ b/src/components/dashboard/dashboard.constants.js
@@ -1,6 +1,7 @@
 export const SENSOR_TOPIC = "growSensors";
 export const LIVE_NOW_TOPIC = "live_now";
-export const topics = [SENSOR_TOPIC, "rootImages", "waterOutput", "waterTank", LIVE_NOW_TOPIC];
+// Topic list used for device-level streams; excludes aggregated `live_now` data
+export const topics = [SENSOR_TOPIC, "rootImages", "waterOutput", "waterTank"];
 
 export const bandMap = {
   F1: "415nm",

--- a/tests/SensorDashboardOverview.test.jsx
+++ b/tests/SensorDashboardOverview.test.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render, screen, within, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+import SensorDashboard from '../src/components/SensorDashboard';
+import { FiltersProvider } from '../src/context/FiltersContext';
+
+// Mock WebSocket hook so we can control messages
+vi.mock('../src/hooks/useStomp', () => ({
+  useStomp: (topics, onMessage) => {
+    const list = Array.isArray(topics) ? topics : [topics];
+    list.forEach((t) => {
+      if (t === 'live_now') {
+        global.__liveNowHandler = onMessage;
+      }
+    });
+  },
+}));
+
+// Stub components that are not relevant for this test
+vi.mock('../src/components/SpectrumBarChart', () => ({ default: () => <div /> }));
+vi.mock('../src/components/Header', () => ({ default: () => <div /> }));
+vi.mock('../src/components/dashboard/TopicSection', () => ({ default: () => <div /> }));
+vi.mock('../src/components/dashboard/NotesBlock', () => ({ default: () => <div /> }));
+
+test('overview items reflect live_now data', () => {
+  render(
+    <FiltersProvider>
+      <SensorDashboard />
+    </FiltersProvider>
+  );
+
+  act(() => {
+    global.__liveNowHandler('live_now', {
+      light: { average: 100, deviceCount: 1 },
+      humidity: { average: 50, deviceCount: 2 },
+      temperature: { average: 25, deviceCount: 3 },
+      dissolvedOxygen: { average: 8, deviceCount: 4 },
+      airpump: { average: 1, deviceCount: 5 },
+    });
+  });
+
+  const lightBox = screen.getByTitle('Light');
+  expect(within(lightBox).getByText('100')).toBeInTheDocument();
+
+  const tempBox = screen.getByTitle('Temperature');
+  expect(within(tempBox).getByText('25')).toBeInTheDocument();
+});
+


### PR DESCRIPTION
## Summary
- derive sensor overview metrics from aggregated `live_now` WebSocket feed
- remove `live_now` from device-level topics list
- add unit test confirming overview reflects `live_now` data

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689922b2ef688328b6718b08e0f6cf25