### PR TITLE
Show device name in report chart titles

### DIFF
--- a/src/components/dashboard/ReportCharts.jsx
+++ b/src/components/dashboard/ReportCharts.jsx
@@ -19,14 +19,17 @@ function ReportCharts({
   phRangeData,
   ecTdsRangeData,
   doRangeData,
-  xDomain
+  xDomain,
+  selectedDevice
 }) {
+  const withDevice = (title) => (selectedDevice ? `${title}(${selectedDevice})` : title);
+
   return (
     <>
       {showTempHum && (
         <div className={styles.historyChartsRow}>
           <div className={styles.historyChartColumn}>
-            <h3 className={styles.sectionTitle}>Temperature</h3>
+            <h3 className={styles.sectionTitle}>{withDevice('Temperature')}</h3>
             <div className={styles.dailyTempChartWrapper}>
               <HistoricalTemperatureChart data={tempRangeData} xDomain={xDomain} />
             </div>
@@ -37,7 +40,7 @@ function ReportCharts({
       {showSpectrum && (
         <div className={styles.historyChartsRow}>
           <div className={styles.historyChartColumn}>
-            <h3 className={styles.sectionTitle}>Spectrum</h3>
+            <h3 className={styles.sectionTitle}>{withDevice('Spectrum')}</h3>
             <div className={styles.multiBandChartWrapper}>
               <HistoricalMultiBandChart
                 data={rangeData}
@@ -52,7 +55,7 @@ function ReportCharts({
       {showClearLux && (
         <div className={styles.historyChartsRow}>
           <div className={styles.historyChartColumn}>
-            <h3 className={styles.sectionTitle}>Lux_Clear</h3>
+            <h3 className={styles.sectionTitle}>{withDevice('Lux_Clear')}</h3>
             <div className={styles.clearLuxChartWrapper}>
               <HistoricalClearLuxChart data={rangeData} xDomain={xDomain} />
             </div>
@@ -64,7 +67,7 @@ function ReportCharts({
         <div className={styles.historyChartsRow}>
           {showPh && (
             <div className={styles.historyChartColumn}>
-              <h3 className={styles.sectionTitle}>pH</h3>
+              <h3 className={styles.sectionTitle}>{withDevice('pH')}</h3>
               <div className={styles.phChartWrapper}>
                 <HistoricalPhChart data={phRangeData} xDomain={xDomain} />
               </div>
@@ -72,7 +75,7 @@ function ReportCharts({
           )}
           {showEcTds && (
             <div className={styles.historyChartColumn}>
-              <h3 className={styles.sectionTitle}>EC &amp; TDS</h3>
+              <h3 className={styles.sectionTitle}>{withDevice('EC & TDS')}</h3>
               <div className={styles.ecTdsChartWrapper}>
                 <HistoricalEcTdsChart data={ecTdsRangeData} xDomain={xDomain} />
               </div>
@@ -84,7 +87,7 @@ function ReportCharts({
       {showDo && (
         <div className={styles.historyChartsRow}>
           <div className={styles.historyChartColumn}>
-            <h3 className={styles.sectionTitle}>Dissolved Oxygen</h3>
+            <h3 className={styles.sectionTitle}>{withDevice('Dissolved Oxygen')}</h3>
             <div className={styles.doChartWrapper}>
               <HistoricalDoChart data={doRangeData} xDomain={xDomain} />
             </div>

--- a/src/pages/ReportsPage.jsx
+++ b/src/pages/ReportsPage.jsx
@@ -192,6 +192,7 @@ function ReportsPage() {
                                 ecTdsRangeData={ecTdsRangeData}
                                 doRangeData={doRangeData}
                                 xDomain={xDomain}
+                                selectedDevice={selectedDevice}
                             />
                         </>
                     )}

--- a/tests/ReportChartsDeviceTitle.test.jsx
+++ b/tests/ReportChartsDeviceTitle.test.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+import ReportCharts from '../src/components/dashboard/ReportCharts';
+
+vi.mock('../src/components/HistoricalTemperatureChart', () => ({ default: () => <div /> }));
+vi.mock('../src/components/HistoricalMultiBandChart', () => ({ default: () => <div /> }));
+vi.mock('../src/components/HistoricalClearLuxChart', () => ({ default: () => <div /> }));
+vi.mock('../src/components/HistoricalPhChart', () => ({ default: () => <div /> }));
+vi.mock('../src/components/HistoricalEcTdsChart', () => ({ default: () => <div /> }));
+vi.mock('../src/components/HistoricalDoChart', () => ({ default: () => <div /> }));
+
+function setup() {
+  render(
+    <ReportCharts
+      showTempHum
+      showSpectrum={false}
+      showClearLux={false}
+      showPh={false}
+      showEcTds={false}
+      showDo={false}
+      rangeData={[]}
+      tempRangeData={[]}
+      phRangeData={[]}
+      ecTdsRangeData={[]}
+      doRangeData={[]}
+      xDomain={[]}
+      selectedDevice="L01G03"
+    />
+  );
+}
+
+test('adds selected device to chart titles', () => {
+  setup();
+  expect(screen.getByText('Temperature(L01G03)')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- Append selected device ID to report chart section headers
- Forward chosen device from ReportsPage to ReportCharts
- Test that chart titles include the device ID

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a4953e0088328b5de8d2a7f180fd5