### PR TITLE
refactor: reference devices by composite ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This project is a React dashboard that subscribes to an MQTT broker and visualis
 The application provides two main views in addition to the default dashboard:
 
 - **Live** – displays real‑time sensor readings as they arrive. Open the "Live" link in the sidebar or navigate to `/live`.
-- **Reports** – shows historical charts for a selected device and time range. Access it from the sidebar or via `/reports`.
+- **Reports** – shows historical charts for a selected composite ID and time range. Access it from the sidebar or via `/reports`.
 
 ## Setup
 

--- a/src/components/DeviceCard.jsx
+++ b/src/components/DeviceCard.jsx
@@ -13,7 +13,8 @@ function getRowColor(value, range) {
     return '';
 }
 
-function DeviceCard({ deviceId, data }) {
+function DeviceCard({ compositeId, deviceId, data }) {
+    const id = compositeId || deviceId;
     const rows = [];
     for (const [field, valueObj] of Object.entries(data)) {
         if (field === 'health') continue;
@@ -42,7 +43,7 @@ function DeviceCard({ deviceId, data }) {
 
     return (
         <div className={styles.card}>
-            <div className={styles.header}>{deviceId}</div>
+            <div className={styles.header}>{id}</div>
             <div className={styles.body}>
                 <table className={styles.table}>
                     <thead>

--- a/src/components/DeviceTable.jsx
+++ b/src/components/DeviceTable.jsx
@@ -86,12 +86,7 @@ function DeviceTable({devices = {}}) {
                     <th className={styles.modelCell}>Max</th>
                     {deviceIds.map(id => {
                         const dev = devices[id];
-                        const loc = dev?.location ?? dev?.Location ?? dev?.meta?.location ?? "";
-                        let baseId = dev?.deviceId ?? id;
-                        if (!dev?.deviceId && loc && id.startsWith(loc)) {
-                            baseId = id.slice(loc.length);
-                        }
-                        const label = loc ? `${loc}${baseId}` : baseId;
+                        const label = dev?.compositeId ?? id;
                         return <th key={id}>{label}</th>;
                     })}
                 </tr>

--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -126,7 +126,7 @@ function SensorDashboard() {
                 value: metric("light").average ?? "—",
                 unit: metric("light").average != null ? "lx" : "",
                 title: "Light",
-                subtitle: `Devices: ${metric("light").deviceCount ?? 0}`,
+                subtitle: `Composite IDs: ${metric("light").deviceCount ?? 0}`,
             },
             {
                 key: "temperature",
@@ -134,7 +134,7 @@ function SensorDashboard() {
                 value: metric("temperature").average ?? "—",
                 unit: metric("temperature").average != null ? "℃" : "",
                 title: "Temperature",
-                subtitle: `Devices: ${metric("temperature").deviceCount ?? 0}`,
+                subtitle: `Composite IDs: ${metric("temperature").deviceCount ?? 0}`,
             },
             {
                 key: "humidity",
@@ -142,7 +142,7 @@ function SensorDashboard() {
                 value: metric("humidity").average ?? "—",
                 unit: metric("humidity").average != null ? "%" : "",
                 title: "Humidity",
-                subtitle: `Devices: ${metric("humidity").deviceCount ?? 0}`,
+                subtitle: `Composite IDs: ${metric("humidity").deviceCount ?? 0}`,
             },
             {
                 key: "dissolvedOxygen",
@@ -150,7 +150,7 @@ function SensorDashboard() {
                 value: metric("dissolvedOxygen").average ?? "—",
                 unit: metric("dissolvedOxygen").average != null ? "mg/L" : "",
                 title: "DO",
-                subtitle: `Devices: ${metric("dissolvedOxygen").deviceCount ?? 0}`,
+                subtitle: `Composite IDs: ${metric("dissolvedOxygen").deviceCount ?? 0}`,
             },
             {
                 key: "airpump",
@@ -158,7 +158,7 @@ function SensorDashboard() {
                 value: metric("airpump").average ?? "—",
                 unit: "",
                 title: "Air Pump",
-                subtitle: `Devices: ${metric("airpump").deviceCount ?? 0}`,
+                subtitle: `Composite IDs: ${metric("airpump").deviceCount ?? 0}`,
             },
         ];
     }, [liveNow]);
@@ -180,7 +180,7 @@ function SensorDashboard() {
                         <>
                             <div className={styles.chartFilterRow}>
                                 <label className={styles.filterLabel}>
-                                    Device:
+                                    Composite ID:
                                     <select
                                         className={styles.intervalSelect}
                                         value={selectedDevice}

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -86,7 +86,7 @@ export default function Sidebar() {
                 {!collapsed && <div className={styles.filtersTitle}>Application filters</div>}
 
                 <CheckboxGroup title="Topic" list={lists.topics} value={topic} onChange={setTopic} />
-                <CheckboxGroup title="Device" list={lists.devices} value={device} onChange={setDevice} />
+                <CheckboxGroup title="Composite ID" list={lists.devices} value={device} onChange={setDevice} />
                 <CheckboxGroup title="Layer" list={lists.layers} value={layer} onChange={setLayer} />
                 <CheckboxGroup title="System" list={lists.systems} value={system} onChange={setSystem} />
             </section>

--- a/src/components/dashboard/NotesBlock.jsx
+++ b/src/components/dashboard/NotesBlock.jsx
@@ -4,7 +4,7 @@ import idealRangeConfig from '../../idealRangeConfig.js';
 import {bandMap, knownFields} from './dashboard.constants';
 
 function NotesBlock({ mergedDevices = {} }) {
-  const metaFields = new Set(['timestamp', 'deviceId', 'location']);
+  const metaFields = new Set(['timestamp', 'deviceId', 'compositeId', 'location']);
 
   const sensors = new Set();
   for (const dev of Object.values(mergedDevices)) {

--- a/src/components/dashboard/ReportControls.jsx
+++ b/src/components/dashboard/ReportControls.jsx
@@ -40,7 +40,7 @@ function ReportControls({
 
       <div className={styles.filterRow}>
         <label className={styles.filterLabel}>
-          Device:
+          Composite ID:
           <select className={styles.intervalSelect} value={selectedDevice} onChange={onDeviceChange}>
             {availableCompositeIds.map((id) => (
               <option key={id} value={id}>

--- a/src/pages/ReportsPage.jsx
+++ b/src/pages/ReportsPage.jsx
@@ -159,7 +159,7 @@ function ReportsPage() {
             <div className={styles.section}>
                 <div className={styles.sectionBody}>
                     {!showAnyReport ? (
-                        <div>No reports available for this device.</div>
+                        <div>No reports available for this composite ID.</div>
                     ) : (
                         <>
                             <ReportControls

--- a/tests/AppReportsRoute.test.jsx
+++ b/tests/AppReportsRoute.test.jsx
@@ -35,6 +35,6 @@ test('reports link retains base path and is active when served from subdirectory
   render(<App />);
   const link = screen.getByRole('link', { name: /reports/i });
   expect(link).toHaveAttribute('href', '/NFTMonitoring/reports');
-  + // In React Router v6 for the active page, aria-current='page' is set
+  // In React Router v6 for the active page, aria-current='page' is set
   expect(link).toHaveAttribute('aria-current', 'page');
 });

--- a/tests/Reports.test.jsx
+++ b/tests/Reports.test.jsx
@@ -70,7 +70,7 @@ test('Reports page shows charts for AS7343 and SHT3x sensors (case-insensitive)'
   });
 
   render(<ReportsPage />);
-  expect(screen.queryByText('No reports available for this device.')).toBeNull();
+  expect(screen.queryByText('No reports available for this composite ID.')).toBeNull();
   expect(ReportCharts).toHaveBeenCalled();
   const props = ReportCharts.mock.calls[0][0];
   expect(props.showSpectrum).toBe(true);
@@ -98,6 +98,6 @@ test('Reports page defaults to first available system when initial system has no
 
   render(<ReportsPage />);
   await waitFor(() => expect(ReportCharts).toHaveBeenCalled());
-  expect(screen.queryByText('No reports available for this device.')).toBeNull();
+  expect(screen.queryByText('No reports available for this composite ID.')).toBeNull();
 });
 


### PR DESCRIPTION
## Summary
- label device selectors and counts as "Composite ID"
- show compositeId in device tables and cards
- update tests and docs for composite ID terminology

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689a4f815b888328bf8ef9a01f720691