### PR TITLE
Decouple overview and live dashboard views

### DIFF
--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -9,7 +9,7 @@ import {SENSOR_TOPIC, topics} from "./dashboard/dashboard.constants";
 import {useFilters, ALL} from "../context/FiltersContext";
 import Overview from "./dashboard/Overview";
 
-function SensorDashboard() {
+function SensorDashboard({ view }) {
     const [activeSystem, setActiveSystem] = useState("S01");
     const {deviceData, sensorData, availableCompositeIds, mergedDevices} = useLiveDevices(topics, activeSystem);
     // aggregated metrics from the `live_now` topic
@@ -165,18 +165,19 @@ function SensorDashboard() {
         <div className={styles.dashboard}>
             <Header system={activeSystem}/>
 
-            {/* ⬇️ NEW Overview (replaces SystemTabs) */}
-            <Overview items={overviewItems}/>
+            {view !== 'live' && <Overview items={overviewItems}/>}
 
-            <Live
-                filteredSystemTopics={filteredSystemTopics}
-                sensorTopicDevices={sensorTopicDevices}
-                selectedDevice={selectedDevice}
-                setSelectedDevice={setSelectedDevice}
-                filteredCompositeIds={filteredCompositeIds}
-                sensorData={sensorData}
-                mergedDevices={mergedDevices}
-            />
+            {view !== 'overview' && (
+                <Live
+                    filteredSystemTopics={filteredSystemTopics}
+                    sensorTopicDevices={sensorTopicDevices}
+                    selectedDevice={selectedDevice}
+                    setSelectedDevice={setSelectedDevice}
+                    filteredCompositeIds={filteredCompositeIds}
+                    sensorData={sensorData}
+                    mergedDevices={mergedDevices}
+                />
+            )}
         </div>
     );
 }

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import SensorDashboard from '../components/SensorDashboard';
 
 function Dashboard() {
-    return <SensorDashboard />;
+    return <SensorDashboard view="overview" />;
 }
 
 export default Dashboard;


### PR DESCRIPTION
## Summary
- Allow SensorDashboard to render overview or live sections independently
- Show only overview on Dashboard route

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_689bafcad37c8328a0cfc1930f549fa1