### PR TITLE
Replace system header with page titles

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,7 +1,7 @@
-import React, {useEffect, useState} from 'react';
+import React, { useEffect, useState } from 'react';
 import styles from './Header.module.css';
 
-function Header({system}) {
+function Header({ title }) {
     const [now, setNow] = useState(() => new Date());
 
     useEffect(() => {
@@ -11,7 +11,7 @@ function Header({system}) {
 
     return (
         <header className={styles.header}>
-            <h1 className={styles.title}>{system} Dashboard</h1>
+            <h1 className={styles.title}>{title}</h1>
             <div className={styles.time}>{now.toLocaleTimeString()}</div>
         </header>
     );

--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -9,7 +9,7 @@ import {SENSOR_TOPIC, topics} from "./dashboard/dashboard.constants";
 import {useFilters, ALL} from "../context/FiltersContext";
 import Overview from "./dashboard/Overview";
 
-function SensorDashboard({ view }) {
+function SensorDashboard({ view, title = '' }) {
     const [activeSystem, setActiveSystem] = useState("S01");
     const {deviceData, sensorData, availableCompositeIds, mergedDevices} = useLiveDevices(topics, activeSystem);
     // aggregated metrics from the `live_now` topic
@@ -163,7 +163,7 @@ function SensorDashboard({ view }) {
 
     return (
         <div className={styles.dashboard}>
-            <Header system={activeSystem}/>
+            <Header title={title}/>
 
             {view !== 'live' && <Overview items={overviewItems}/>}
 

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import SensorDashboard from '../components/SensorDashboard';
 
 function Dashboard() {
-    return <SensorDashboard view="overview" />;
+    return <SensorDashboard view="overview" title="Dashboard" />;
 }
 
 export default Dashboard;

--- a/src/pages/Live.jsx
+++ b/src/pages/Live.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import SensorDashboard from '../components/SensorDashboard';
 
 function Live() {
-    return <SensorDashboard view="live" />;
+    return <SensorDashboard view="live" title="Live" />;
 }
 
 export default Live;

--- a/src/pages/ReportsPage.jsx
+++ b/src/pages/ReportsPage.jsx
@@ -151,7 +151,7 @@ function ReportsPage() {
 
     return (
         <div className={styles.dashboard}>
-            <Header system={activeSystem} />
+            <Header title="Reports" />
 
             {/* System selection tabs */}
             <SystemTabs systems={Object.keys(deviceData)} activeSystem={activeSystem} onChange={setActiveSystem} />

--- a/tests/Header.test.jsx
+++ b/tests/Header.test.jsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import Header from '../src/components/Header';
 
-test('renders system title', () => {
-    render(<Header system="S01" />);
-    expect(screen.getByText('S01 Dashboard')).toBeInTheDocument();
+test('renders header title', () => {
+    render(<Header title="Reports" />);
+    expect(screen.getByText('Reports')).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- show page name instead of active system in header
- forward titles from Dashboard, Live and Reports pages
- update unit test

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_689bb2ae2258832894fe502620abd6e7