### PR TITLE
feat: add dashboard components

### DIFF
--- a/src/components/dashboard/DeviceCard.jsx
+++ b/src/components/dashboard/DeviceCard.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import MetricCard from './MetricCard';
+
+export default function DeviceCard({ name, metrics = {} }) {
+    return (
+        <div className="bg-white border rounded shadow-sm p-4">
+            <h4 className="font-medium mb-2">{name}</h4>
+            <div className="grid grid-cols-2 gap-2">
+                {Object.entries(metrics).map(([key, val]) => (
+                    <MetricCard key={key} title={key} value={val} />
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/src/components/dashboard/LayerMetrics.jsx
+++ b/src/components/dashboard/LayerMetrics.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import MetricCard from './MetricCard';
+
+export default function LayerMetrics({ metrics = {} }) {
+    return (
+        <div className="grid grid-cols-2 gap-2">
+            {Object.entries(metrics).map(([key, val]) => (
+                <MetricCard key={key} title={key} value={val} />
+            ))}
+        </div>
+    );
+}

--- a/src/components/dashboard/LayersBoard.jsx
+++ b/src/components/dashboard/LayersBoard.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import DeviceCard from './DeviceCard';
+import LayerMetrics from './LayerMetrics';
+
+export default function LayersBoard({ layers = [] }) {
+    return (
+        <div className="space-y-4">
+            {layers.map((layer) => (
+                <div key={layer.id} className="bg-gray-50 rounded p-4">
+                    <div className="flex justify-between items-start mb-4">
+                        <h3 className="text-lg font-semibold">{layer.name}</h3>
+                        {layer.metrics ? <LayerMetrics metrics={layer.metrics} /> : null}
+                    </div>
+                    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                        {layer.devices?.map((dev) => (
+                            <DeviceCard key={dev.id} name={dev.name} metrics={dev.metrics} />
+                        ))}
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/src/components/dashboard/MetricCard.jsx
+++ b/src/components/dashboard/MetricCard.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function MetricCard({ title, value, unit }) {
+    return (
+        <div className="bg-white rounded shadow p-4 text-center">
+            <div className="text-sm text-gray-500">{title}</div>
+            <div className="text-2xl font-semibold">
+                {value}
+                {unit ? <span className="ml-1 text-base font-normal">{unit}</span> : null}
+            </div>
+        </div>
+    );
+}

--- a/src/components/dashboard/OverviewList.jsx
+++ b/src/components/dashboard/OverviewList.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import MetricCard from './MetricCard';
+
+export default function OverviewList({ systems = [] }) {
+    return (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {systems.map((sys) => (
+                <div key={sys.id} className="bg-white rounded shadow p-4">
+                    <h3 className="text-lg font-semibold mb-2">{sys.name}</h3>
+                    <div className="grid grid-cols-2 gap-2">
+                        {sys.metrics &&
+                            Object.entries(sys.metrics).map(([key, val]) => (
+                                <MetricCard key={key} title={key} value={val} />
+                            ))}
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/src/components/dashboard/SystemSelect.jsx
+++ b/src/components/dashboard/SystemSelect.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export default function SystemSelect({ systems = [], value, onChange }) {
+    return (
+        <select
+            className="border rounded p-2"
+            value={value}
+            onChange={(e) => onChange?.(e.target.value)}
+        >
+            {systems.map((sys) => (
+                <option key={sys.id} value={sys.id}>
+                    {sys.name}
+                </option>
+            ))}
+        </select>
+    );
+}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,8 +1,2 @@
-import React from 'react';
-import SensorDashboard from '../components/SensorDashboard';
-
-function Dashboard() {
-    return <SensorDashboard view="overview" title="Dashboard" />;
-}
-
-export default Dashboard;
+import DashboardPage from './DashboardPage';
+export default DashboardPage;

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+import SystemSelect from '../components/dashboard/SystemSelect';
+import OverviewList from '../components/dashboard/OverviewList';
+import LayersBoard from '../components/dashboard/LayersBoard';
+
+export default function DashboardPage() {
+    const systems = [
+        { id: 'sys-a', name: 'System A', metrics: { temp: 25, ph: 6.5 } },
+        { id: 'sys-b', name: 'System B', metrics: { temp: 27, ph: 7.0 } },
+    ];
+
+    const layers = [
+        {
+            id: 'layer-1',
+            name: 'Layer 1',
+            metrics: { moisture: 80 },
+            devices: [
+                { id: 'd1', name: 'Device 1', metrics: { temp: 24 } },
+                { id: 'd2', name: 'Device 2', metrics: { temp: 25 } },
+            ],
+        },
+    ];
+
+    const [selected, setSelected] = useState(systems[0].id);
+
+    return (
+        <div className="space-y-6 p-6">
+            <div className="flex justify-end">
+                <SystemSelect systems={systems} value={selected} onChange={setSelected} />
+            </div>
+            <OverviewList systems={systems} />
+            <LayersBoard layers={layers} />
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- add Tailwind-based dashboard widgets: metric card, system overview list, system selector, layers board
- compose new DashboardPage from these widgets

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c28a23e14832885a4ae1b412e7209