### PR TITLE
feat: add dashboard components

### DIFF
--- a/src/components/dashboard/DeviceCard.jsx
+++ b/src/components/dashboard/DeviceCard.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import MetricCard from './MetricCard';
+import styles from './DeviceCard.module.css';
+
+export default function DeviceCard({ name, metrics = {} }) {
+    return (
+        <div className={styles.card}>
+            <h4 className={styles.title}>{name}</h4>
+            <div className={styles.metrics}>
+                {Object.entries(metrics).map(([key, val]) => (
+                    <MetricCard key={key} title={key} value={val} />
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/src/components/dashboard/DeviceCard.module.css
+++ b/src/components/dashboard/DeviceCard.module.css
@@ -1,0 +1,16 @@
+.card {
+    background: #ffffff;
+    border: 1px solid #e5e7eb;
+    border-radius: 4px;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+    padding: 16px;
+}
+.title {
+    font-weight: 500;
+    margin-bottom: 8px;
+}
+.metrics {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 8px;
+}

--- a/src/components/dashboard/LayerMetrics.jsx
+++ b/src/components/dashboard/LayerMetrics.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import MetricCard from './MetricCard';
+import styles from './LayerMetrics.module.css';
+
+export default function LayerMetrics({ metrics = {} }) {
+    return (
+        <div className={styles.grid}>
+            {Object.entries(metrics).map(([key, val]) => (
+                <MetricCard key={key} title={key} value={val} />
+            ))}
+        </div>
+    );
+}

--- a/src/components/dashboard/LayerMetrics.module.css
+++ b/src/components/dashboard/LayerMetrics.module.css
@@ -1,0 +1,5 @@
+.grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 8px;
+}

--- a/src/components/dashboard/LayersBoard.jsx
+++ b/src/components/dashboard/LayersBoard.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import DeviceCard from './DeviceCard';
+import LayerMetrics from './LayerMetrics';
+import styles from './LayersBoard.module.css';
+
+export default function LayersBoard({ layers = [] }) {
+    return (
+        <div className={styles.board}>
+            {layers.map((layer) => (
+                <div key={layer.id} className={styles.layerCard}>
+                    <div className={styles.header}>
+                        <h3 className={styles.title}>{layer.name}</h3>
+                        {layer.metrics ? <LayerMetrics metrics={layer.metrics} /> : null}
+                    </div>
+                    <div className={styles.devices}>
+                        {layer.devices?.map((dev) => (
+                            <DeviceCard key={dev.id} name={dev.name} metrics={dev.metrics} />
+                        ))}
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/src/components/dashboard/LayersBoard.module.css
+++ b/src/components/dashboard/LayersBoard.module.css
@@ -1,0 +1,34 @@
+.board {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+.layerCard {
+    background: #f9fafb;
+    border-radius: 4px;
+    padding: 16px;
+}
+.header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 16px;
+}
+.title {
+    font-size: 18px;
+    font-weight: 600;
+}
+.devices {
+    display: grid;
+    gap: 16px;
+}
+@media (min-width: 640px) {
+    .devices {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+@media (min-width: 1024px) {
+    .devices {
+        grid-template-columns: repeat(3, 1fr);
+    }
+}

--- a/src/components/dashboard/MetricCard.jsx
+++ b/src/components/dashboard/MetricCard.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import styles from './MetricCard.module.css';
+
+export default function MetricCard({ title, value, unit }) {
+    return (
+        <div className={styles.card}>
+            <div className={styles.title}>{title}</div>
+            <div className={styles.value}>
+                {value}
+                {unit ? <span className={styles.unit}>{unit}</span> : null}
+            </div>
+        </div>
+    );
+}

--- a/src/components/dashboard/MetricCard.module.css
+++ b/src/components/dashboard/MetricCard.module.css
@@ -1,0 +1,20 @@
+.card {
+    background: #ffffff;
+    border-radius: 4px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    padding: 16px;
+    text-align: center;
+}
+.title {
+    font-size: 14px;
+    color: #6b7280;
+}
+.value {
+    font-size: 24px;
+    font-weight: 600;
+}
+.unit {
+    margin-left: 4px;
+    font-size: 16px;
+    font-weight: 400;
+}

--- a/src/components/dashboard/OverviewList.jsx
+++ b/src/components/dashboard/OverviewList.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import MetricCard from './MetricCard';
+import styles from './OverviewList.module.css';
+
+export default function OverviewList({ systems = [] }) {
+    return (
+        <div className={styles.grid}>
+            {systems.map((sys) => (
+                <div key={sys.id} className={styles.card}>
+                    <h3 className={styles.title}>{sys.name}</h3>
+                    <div className={styles.metrics}>
+                        {sys.metrics &&
+                            Object.entries(sys.metrics).map(([key, val]) => (
+                                <MetricCard key={key} title={key} value={val} />
+                            ))}
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/src/components/dashboard/OverviewList.module.css
+++ b/src/components/dashboard/OverviewList.module.css
@@ -1,0 +1,30 @@
+.grid {
+    display: grid;
+    gap: 16px;
+}
+@media (min-width: 640px) {
+    .grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+@media (min-width: 1024px) {
+    .grid {
+        grid-template-columns: repeat(3, 1fr);
+    }
+}
+.card {
+    background: #ffffff;
+    border-radius: 4px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    padding: 16px;
+}
+.title {
+    font-size: 18px;
+    font-weight: 600;
+    margin-bottom: 8px;
+}
+.metrics {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 8px;
+}

--- a/src/components/dashboard/SystemSelect.jsx
+++ b/src/components/dashboard/SystemSelect.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import styles from './SystemSelect.module.css';
+
+export default function SystemSelect({ systems = [], value, onChange }) {
+    return (
+        <select
+            className={styles.select}
+            value={value}
+            onChange={(e) => onChange?.(e.target.value)}
+        >
+            {systems.map((sys) => (
+                <option key={sys.id} value={sys.id}>
+                    {sys.name}
+                </option>
+            ))}
+        </select>
+    );
+}

--- a/src/components/dashboard/SystemSelect.module.css
+++ b/src/components/dashboard/SystemSelect.module.css
@@ -1,0 +1,5 @@
+.select {
+    border: 1px solid #d1d5db;
+    border-radius: 4px;
+    padding: 8px;
+}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,8 +1,2 @@
-import React from 'react';
-import SensorDashboard from '../components/SensorDashboard';
-
-function Dashboard() {
-    return <SensorDashboard view="overview" title="Dashboard" />;
-}
-
-export default Dashboard;
+import DashboardPage from './DashboardPage';
+export default DashboardPage;

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+import SystemSelect from '../components/dashboard/SystemSelect';
+import OverviewList from '../components/dashboard/OverviewList';
+import LayersBoard from '../components/dashboard/LayersBoard';
+import styles from './DashboardPage.module.css';
+
+export default function DashboardPage() {
+    const systems = [
+        { id: 'sys-a', name: 'System A', metrics: { temp: 25, ph: 6.5 } },
+        { id: 'sys-b', name: 'System B', metrics: { temp: 27, ph: 7.0 } },
+    ];
+
+    const layers = [
+        {
+            id: 'layer-1',
+            name: 'Layer 1',
+            metrics: { moisture: 80 },
+            devices: [
+                { id: 'd1', name: 'Device 1', metrics: { temp: 24 } },
+                { id: 'd2', name: 'Device 2', metrics: { temp: 25 } },
+            ],
+        },
+    ];
+
+    const [selected, setSelected] = useState(systems[0].id);
+
+    return (
+        <div className={styles.page}>
+            <div className={styles.header}>
+                <SystemSelect systems={systems} value={selected} onChange={setSelected} />
+            </div>
+            <OverviewList systems={systems} />
+            <LayersBoard layers={layers} />
+        </div>
+    );
+}

--- a/src/pages/DashboardPage.module.css
+++ b/src/pages/DashboardPage.module.css
@@ -1,0 +1,10 @@
+.page {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    padding: 24px;
+}
+.header {
+    display: flex;
+    justify-content: flex-end;
+}


### PR DESCRIPTION
## Summary
- move dashboard widgets from inline Tailwind classes to CSS modules for consistent styling
- apply CSS modules across MetricCard, DeviceCard, LayerMetrics, LayersBoard, OverviewList, SystemSelect, and page layout

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_689c28a23e14832885a4ae1b412e7209