### PR TITLE
Connect dashboard to live WebSocket updates

### DIFF
--- a/src/components/dashboard/LayersBoard.jsx
+++ b/src/components/dashboard/LayersBoard.jsx
@@ -13,10 +13,11 @@ export default function LayersBoard({ layers = [] }) {
                         {layer.metrics ? <LayerMetrics metrics={layer.metrics} /> : null}
                     </div>
                     <div className={styles.devices}>
-                    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                        {layer.devices?.map((dev) => (
-                            <DeviceCard key={dev.id} name={dev.name} metrics={dev.metrics} />
-                        ))}
+                        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                            {layer.devices?.map((dev) => (
+                                <DeviceCard key={dev.id} name={dev.name} metrics={dev.metrics} />
+                            ))}
+                        </div>
                     </div>
                 </div>
             ))}

--- a/src/hooks/useLiveUpdates.js
+++ b/src/hooks/useLiveUpdates.js
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+import { Client } from '@stomp/stompjs';
+
+/**
+ * Hook that connects to the WebSocket and subscribes to `/topic/live_now`.
+ * Returns the latest parsed JSON payload received from the topic.
+ */
+export function useLiveUpdates() {
+    const [payload, setPayload] = useState(null);
+
+    useEffect(() => {
+        let wsUrl = import.meta.env.VITE_WS_URL || 'wss://api.hydroleaf.se/ws';
+        if (typeof window !== 'undefined' && window.location.protocol === 'https:' && wsUrl.startsWith('ws://')) {
+            wsUrl = 'wss://' + wsUrl.slice(5);
+        }
+
+        const client = new Client({
+            brokerURL: wsUrl,
+            reconnectDelay: 5000,
+            debug: () => {},
+        });
+
+        client.onConnect = () => {
+            client.subscribe('/topic/live_now', (message) => {
+                try {
+                    const data = JSON.parse(message.body);
+                    setPayload(data);
+                } catch (e) {
+                    console.error('Failed to parse live update', e);
+                }
+            });
+        };
+
+        client.onStompError = (frame) => {
+            console.error('STOMP error', frame.headers['message']);
+        };
+
+        client.activate();
+
+        return () => {
+            client.deactivate();
+        };
+    }, []);
+
+    return payload;
+}

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -1,16 +1,17 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import SystemSelect from '../components/dashboard/SystemSelect';
 import OverviewList from '../components/dashboard/OverviewList';
 import LayersBoard from '../components/dashboard/LayersBoard';
 import styles from './DashboardPage.module.css';
+import { useLiveUpdates } from '../hooks/useLiveUpdates';
 
 export default function DashboardPage() {
-    const systems = [
+    const [systems, setSystems] = useState([
         { id: 'sys-a', name: 'System A', metrics: { temp: 25, ph: 6.5 } },
         { id: 'sys-b', name: 'System B', metrics: { temp: 27, ph: 7.0 } },
-    ];
+    ]);
 
-    const layers = [
+    const [layers, setLayers] = useState([
         {
             id: 'layer-1',
             name: 'Layer 1',
@@ -20,9 +21,27 @@ export default function DashboardPage() {
                 { id: 'd2', name: 'Device 2', metrics: { temp: 25 } },
             ],
         },
-    ];
+    ]);
 
-    const [selected, setSelected] = useState(systems[0].id);
+    const live = useLiveUpdates();
+
+    useEffect(() => {
+        if (!live) return;
+        if (Array.isArray(live.systems)) {
+            setSystems(live.systems);
+        }
+        if (Array.isArray(live.layers)) {
+            setLayers(live.layers);
+        }
+    }, [live]);
+
+    const [selected, setSelected] = useState('');
+
+    useEffect(() => {
+        if (systems.length && !systems.find((s) => s.id === selected)) {
+            setSelected(systems[0].id);
+        }
+    }, [systems, selected]);
 
     return (
         <div className={styles.page}>


### PR DESCRIPTION
## Summary
- add `useLiveUpdates` hook using `@stomp/stompjs` to subscribe to `/topic/live_now`
- wire `DashboardPage` to update systems and layers from live payloads
- fix LayersBoard markup so device grid renders correctly

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c276575848328b88ebc231d13236f