### PR TITLE
Prefer sensorType over valueType

### DIFF
--- a/src/components/DeviceTable.jsx
+++ b/src/components/DeviceTable.jsx
@@ -20,13 +20,14 @@ function DeviceTable({devices = {}}) {
     const spectralKeyMapFromData = {};
 
     allSensors.forEach(s => {
-        if (s?.valueType) {
-            measurementTypes.add(s.valueType);
-            measurementToSensorModel[s.valueType] = s.sensorName || s.source || '-';
+        const type = s?.sensorType || s?.valueType;
+        if (type) {
+            measurementTypes.add(type);
+            measurementToSensorModel[type] = s.sensorName || s.source || '-';
 
             // Label map (first letter uppercase if common)
-            if (!labelMapFromData[s.valueType]) {
-                const key = s.valueType;
+            if (!labelMapFromData[type]) {
+                const key = type;
                 if (key === 'temperature') labelMapFromData[key] = 'Temp';
                 else if (key === 'humidity') labelMapFromData[key] = 'Hum';
                 else if (key.toLowerCase().includes('oxygen')) labelMapFromData[key] = 'DO';
@@ -34,15 +35,15 @@ function DeviceTable({devices = {}}) {
             }
 
             // Spectral mapping if type is wavelength
-            if (/^\d+nm$/.test(s.valueType)) {
-                const num = s.valueType.replace('nm', '');
+            if (/^\d+nm$/.test(type)) {
+                const num = type.replace('nm', '');
                 const index = ['415', '445', '480', '515', '555', '590', '630', '680'].indexOf(num);
                 if (index !== -1) {
-                    spectralKeyMapFromData[s.valueType] = 'F' + (index + 1);
+                    spectralKeyMapFromData[type] = 'F' + (index + 1);
                 }
             }
-            if (s.valueType === 'clear') spectralKeyMapFromData[s.valueType] = 'clear';
-            if (s.valueType === 'nir') spectralKeyMapFromData[s.valueType] = 'nir';
+            if (type === 'clear') spectralKeyMapFromData[type] = 'clear';
+            if (type === 'nir') spectralKeyMapFromData[type] = 'nir';
         }
     });
 
@@ -61,7 +62,7 @@ function DeviceTable({devices = {}}) {
         const rowColor = bandKey ? `${spectralColors[bandKey]}22` : undefined;
 
         const cells = deviceIds.map(id => {
-            const s = devices[id].sensors?.find(s => s.valueType === measurementType);
+            const s = devices[id].sensors?.find(s => (s.sensorType || s.valueType) === measurementType);
             const value = s?.value;
             const unit = s?.unit || '';
             const display = (value === undefined || value === null) ? '-' : `${typeof value === 'number' ? value.toFixed(1) : value}${unit ? ` ${unit}` : ''}`;

--- a/src/components/dashboard/NotesBlock.jsx
+++ b/src/components/dashboard/NotesBlock.jsx
@@ -10,7 +10,7 @@ function NotesBlock({ mergedDevices = {} }) {
   for (const dev of Object.values(mergedDevices)) {
     if (Array.isArray(dev?.sensors)) {
       for (const s of dev.sensors) {
-        const type = s && (s.type || s.valueType);
+        const type = s && (s.sensorType || s.valueType);
         if (type) sensors.add(bandMap[type] || type);
       }
     }

--- a/src/pages/ReportsPage.jsx
+++ b/src/pages/ReportsPage.jsx
@@ -131,7 +131,7 @@ function ReportsPage() {
     const sensorTypesForSelected = useMemo(() => {
         const match = sensorTopicDevices[selectedDevice];
         const sensors = match?.sensors || [];
-        return sensors.map((s) => (s.type || s.valueType || '').toLowerCase());
+        return sensors.map((s) => (s.sensorType || s.valueType || '').toLowerCase());
     }, [sensorTopicDevices, selectedDevice]);
 
     const sensorNamesForSelected = useMemo(() => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -22,13 +22,13 @@ function normalizeHealth(health = {}) {
     return normalized;
 }
 
-// Flattens sensor array into a single object keyed by valueType (for charts)
+// Flattens sensor array into a single object keyed by sensorType (for charts)
 export function normalizeSensorData(data) {
     const result = {health: {}};
 
     if (Array.isArray(data.sensors)) {
         for (const sensor of data.sensors) {
-            const type = sensor.type || sensor.valueType;
+            const type = sensor.sensorType || sensor.valueType;
             const val = Number(sensor.value);
 
             switch (type) {
@@ -107,7 +107,7 @@ export function transformAggregatedData(data) {
     if (!data || !Array.isArray(data.sensors)) return [];
     const map = {};
     for (const sensor of data.sensors) {
-        const sensorType = sensor.type || sensor.valueType;
+        const sensorType = sensor.sensorType || sensor.valueType;
         const unit = sensor.unit || '';
 
         for (const entry of sensor.data || []) {

--- a/tests/DeviceTable.test.jsx
+++ b/tests/DeviceTable.test.jsx
@@ -7,14 +7,14 @@ import styles from '../src/components/DeviceTable.module.css';
 const devices = {
   dev1: {
     sensors: [
-      { sensorName: 'SHT3x', valueType: 'temperature', value: 22.5, unit: '°C' },
-      { sensorName: 'SHT3x', valueType: 'humidity', value: 55, unit: '%' },
-      { sensorName: 'VEML7700', valueType: 'light', value: 1200, unit: 'lux' },
-      { sensorName: 'HailegeTDS', valueType: 'tds', value: 800, unit: 'ppm' },
-      { sensorName: 'HailegeTDS', valueType: 'ec', value: 1.5, unit: 'mS/cm' },
-      { sensorName: 'E-201', valueType: 'ph', value: 6.2, unit: '' },
-      { sensorName: 'AS7341', valueType: '415nm', value: 10, unit: 'raw' },
-      { sensorName: 'AS7341', valueType: '445nm', value: 20, unit: 'raw' }
+      { sensorName: 'SHT3x', sensorType: 'temperature', value: 22.5, unit: '°C' },
+      { sensorName: 'SHT3x', sensorType: 'humidity', value: 55, unit: '%' },
+      { sensorName: 'VEML7700', sensorType: 'light', value: 1200, unit: 'lux' },
+      { sensorName: 'HailegeTDS', sensorType: 'tds', value: 800, unit: 'ppm' },
+      { sensorName: 'HailegeTDS', sensorType: 'ec', value: 1.5, unit: 'mS/cm' },
+      { sensorName: 'E-201', sensorType: 'ph', value: 6.2, unit: '' },
+      { sensorName: 'AS7341', sensorType: '415nm', value: 10, unit: 'raw' },
+      { sensorName: 'AS7341', sensorType: '445nm', value: 20, unit: 'raw' }
     ],
     health: {
       SHT3x: true,
@@ -63,7 +63,7 @@ test('shows green indicator when health keys are lowercase', () => {
   const devicesLower = {
     dev1: {
       sensors: [
-        { sensorName: 'SHT3x', valueType: 'temperature', value: 22.5, unit: '°C' }
+        { sensorName: 'SHT3x', sensorType: 'temperature', value: 22.5, unit: '°C' }
       ],
       health: { sht3x: true }
     }

--- a/tests/DeviceTableWaterTank.test.jsx
+++ b/tests/DeviceTableWaterTank.test.jsx
@@ -6,10 +6,10 @@ import DeviceTable from '../src/components/DeviceTable';
 const devices = {
   tank1: {
     sensors: [
-      { sensorName: 'HailegeTDS', valueType: 'tds', value: 500, unit: 'ppm' },
-      { sensorName: '', valueType: 'ec', value: 0.8, unit: 'mS/cm', source: 'HailegeTDS' },
-      { sensorName: 'DS18B20', valueType: 'temperature', value: 24.3, unit: '°C' },
-      { sensorName: 'DFROBOT', valueType: 'dissolvedOxygen', value: 3.1, unit: 'mg/L' }
+      { sensorName: 'HailegeTDS', sensorType: 'tds', value: 500, unit: 'ppm' },
+      { sensorName: '', sensorType: 'ec', value: 0.8, unit: 'mS/cm', source: 'HailegeTDS' },
+      { sensorName: 'DS18B20', sensorType: 'temperature', value: 24.3, unit: '°C' },
+      { sensorName: 'DFROBOT', sensorType: 'dissolvedOxygen', value: 3.1, unit: 'mg/L' }
     ],
     health: { HailegeTDS: true, DS18B20: true, DFROBOT: true }
   }

--- a/tests/data/growTemp.json
+++ b/tests/data/growTemp.json
@@ -6,79 +6,79 @@
   "sensors": [
     {
       "sensorName": "sht3x",
-      "valueType": "temperature",
+      "sensorType": "temperature",
       "value": 1,
       "unit": "°C"
     },
     {
       "sensorName": "sht3x",
-      "valueType": "humidity",
+      "sensorType": "humidity",
       "value": 2,
       "unit": "%"
     },
     {
       "sensorName": "veml7700",
-      "valueType": "light",
+      "sensorType": "light",
       "value": 100,
       "unit": "lux"
     },
     {
       "sensorName": "as7341",
-      "valueType": "415nm",
+      "sensorType": "415nm",
       "value": 1,
       "unit": "raw"
     },
     {
       "sensorName": "as7341",
-      "valueType": "445nm",
+      "sensorType": "445nm",
       "value": 2,
       "unit": "raw"
     },
     {
       "sensorName": "as7341",
-      "valueType": "480nm",
+      "sensorType": "480nm",
       "value": 3,
       "unit": "raw"
     },
     {
       "sensorName": "as7341",
-      "valueType": "515nm",
+      "sensorType": "515nm",
       "value": 4,
       "unit": "raw"
     },
     {
       "sensorName": "as7341",
-      "valueType": "555nm",
+      "sensorType": "555nm",
       "value": 5,
       "unit": "raw"
     },
     {
       "sensorName": "as7341",
-      "valueType": "590nm",
+      "sensorType": "590nm",
       "value": 6,
       "unit": "raw"
     },
     {
       "sensorName": "as7341",
-      "valueType": "630nm",
+      "sensorType": "630nm",
       "value": 7,
       "unit": "raw"
     },
     {
       "sensorName": "as7341",
-      "valueType": "680nm",
+      "sensorType": "680nm",
       "value": 8,
       "unit": "raw"
     },
     {
       "sensorName": "as7341",
-      "valueType": "clear",
+      "sensorType": "clear",
       "value": 101,
       "unit": "raw"
     },
     {
       "sensorName": "as7341",
-      "valueType": "nir",
+      "sensorType": "nir",
       "value": 102,
       "unit": "raw"
     }

--- a/tests/data/growTempWithHealthFalse.json
+++ b/tests/data/growTempWithHealthFalse.json
@@ -6,79 +6,79 @@
   "sensors": [
     {
       "sensorName": "sht3x",
-      "valueType": "temperature",
+      "sensorType": "temperature",
       "value": 1,
       "unit": "°C"
     },
     {
       "sensorName": "sht3x",
-      "valueType": "humidity",
+      "sensorType": "humidity",
       "value": 2,
       "unit": "%"
     },
     {
       "sensorName": "veml7700",
-      "valueType": "light",
+      "sensorType": "light",
       "value": 100,
       "unit": "lux"
     },
     {
       "sensorName": "as7341",
-      "valueType": "415nm",
+      "sensorType": "415nm",
       "value": 1,
       "unit": "raw"
     },
     {
       "sensorName": "as7341",
-      "valueType": "445nm",
+      "sensorType": "445nm",
       "value": 2,
       "unit": "raw"
     },
     {
       "sensorName": "as7341",
-      "valueType": "480nm",
+      "sensorType": "480nm",
       "value": 3,
       "unit": "raw"
     },
     {
       "sensorName": "as7341",
-      "valueType": "515nm",
+      "sensorType": "515nm",
       "value": 4,
       "unit": "raw"
     },
     {
       "sensorName": "as7341",
-      "valueType": "555nm",
+      "sensorType": "555nm",
       "value": 5,
       "unit": "raw"
     },
     {
       "sensorName": "as7341",
-      "valueType": "590nm",
+      "sensorType": "590nm",
       "value": 6,
       "unit": "raw"
     },
     {
       "sensorName": "as7341",
-      "valueType": "630nm",
+      "sensorType": "630nm",
       "value": 7,
       "unit": "raw"
     },
     {
       "sensorName": "as7341",
-      "valueType": "680nm",
+      "sensorType": "680nm",
       "value": 8,
       "unit": "raw"
     },
     {
       "sensorName": "as7341",
-      "valueType": "clear",
+      "sensorType": "clear",
       "value": 101,
       "unit": "raw"
     },
     {
       "sensorName": "as7341",
-      "valueType": "nir",
+      "sensorType": "nir",
       "value": 102,
       "unit": "raw"
     }

--- a/tests/data/tankTemp.json
+++ b/tests/data/tankTemp.json
@@ -6,26 +6,26 @@
   "sensors": [
     {
       "sensorName": "HailegeTDS",
-      "valueType": "tds",
+      "sensorType": "tds",
       "value": 1,
       "unit": "ppm"
     },
     {
       "sensorName": "HailegeTDS",
-      "valueType": "ec",
+      "sensorType": "ec",
       "value": 1,
       "unit": "mS/cm",
       "source": "calculated"
     },
     {
       "sensorName": "DS18B20",
-      "valueType": "temperature",
+      "sensorType": "temperature",
       "value": 2,
       "unit": "°C"
     },
     {
       "sensorName": "DFROBOT",
-      "valueType": "dissolvedOxygen",
+      "sensorType": "dissolvedOxygen",
       "value": 3,
       "unit": "mg/L"
     }

--- a/tests/useLiveDevices.test.jsx
+++ b/tests/useLiveDevices.test.jsx
@@ -19,8 +19,8 @@ test('stores sensor data per composite device', () => {
       layer: 'L01',
       system: 'S01',
       sensors: [
-        { type: 'temperature', value: '20' },
-        { type: 'humidity', value: '50' }
+        { sensorType: 'temperature', value: '20' },
+        { sensorType: 'humidity', value: '50' }
       ]
     });
   });
@@ -30,8 +30,8 @@ test('stores sensor data per composite device', () => {
       deviceId: 'G02',
       system: 'S01',
       sensors: [
-        { type: 'temperature', value: '21' },
-        { type: 'humidity', value: '55' }
+        { sensorType: 'temperature', value: '21' },
+        { sensorType: 'humidity', value: '55' }
       ]
     });
   });

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -67,19 +67,19 @@ test('parses numeric strings into numbers', () => {
 test('normalizes sensors array structure', () => {
     const raw = {
         sensors: [
-            { sensorId: 'sht3x-01', type: 'temperature', value: 26.5, unit: '°C' },
-            { sensorId: 'sht3x-01', type: 'humidity', value: 50, unit: '%' },
-            { sensorId: 'veml7700-01', type: 'light', value: 9, unit: 'lux' },
-            { sensorId: 'as7341-01', type: '415nm', value: 3, unit: 'raw' },
-            { sensorId: 'as7341-01', type: '445nm', value: 4, unit: 'raw' },
-            { sensorId: 'as7341-01', type: '480nm', value: 7, unit: 'raw' },
-            { sensorId: 'as7341-01', type: '515nm', value: 9, unit: 'raw' },
-            { sensorId: 'as7341-01', type: '555nm', value: 15, unit: 'raw' },
-            { sensorId: 'as7341-01', type: '590nm', value: 24, unit: 'raw' },
-            { sensorId: 'as7341-01', type: '630nm', value: 27, unit: 'raw' },
-            { sensorId: 'as7341-01', type: '680nm', value: 26, unit: 'raw' },
-            { sensorId: 'tds-01', type: 'tds', value: 89, unit: 'ppm' },
-            { sensorId: 'ec-estimated', type: 'ec', value: 0.14, unit: 'mS/cm' }
+            { sensorId: 'sht3x-01', sensorType: 'temperature', value: 26.5, unit: '°C' },
+            { sensorId: 'sht3x-01', sensorType: 'humidity', value: 50, unit: '%' },
+            { sensorId: 'veml7700-01', sensorType: 'light', value: 9, unit: 'lux' },
+            { sensorId: 'as7341-01', sensorType: '415nm', value: 3, unit: 'raw' },
+            { sensorId: 'as7341-01', sensorType: '445nm', value: 4, unit: 'raw' },
+            { sensorId: 'as7341-01', sensorType: '480nm', value: 7, unit: 'raw' },
+            { sensorId: 'as7341-01', sensorType: '515nm', value: 9, unit: 'raw' },
+            { sensorId: 'as7341-01', sensorType: '555nm', value: 15, unit: 'raw' },
+            { sensorId: 'as7341-01', sensorType: '590nm', value: 24, unit: 'raw' },
+            { sensorId: 'as7341-01', sensorType: '630nm', value: 27, unit: 'raw' },
+            { sensorId: 'as7341-01', sensorType: '680nm', value: 26, unit: 'raw' },
+            { sensorId: 'tds-01', sensorType: 'tds', value: 89, unit: 'ppm' },
+            { sensorId: 'ec-estimated', sensorType: 'ec', value: 0.14, unit: 'mS/cm' }
         ],
         health: { sht3x: true, veml7700: true, as7341: true, tds: true, ph: false }
     };
@@ -98,7 +98,7 @@ test('normalizes sensors array structure', () => {
 test('handles ph sensor readings', () => {
     const raw = {
         sensors: [
-            { type: 'ph', value: 6.2, unit: '' }
+            { sensorType: 'ph', value: 6.2, unit: '' }
         ]
     };
     const result = normalizeSensorData(raw);
@@ -138,7 +138,7 @@ test('filterNoise discards out of range values', () => {
 });
 
 test('parseSensorJson fixes missing commas between sensor objects', () => {
-    const malformed = '{"sensors":[{"sensorId":"a","type":"temperature","value":1}{"sensorId":"b","type":"humidity","value":2}]}';
+    const malformed = '{"sensors":[{"sensorId":"a","sensorType":"temperature","value":1}{"sensorId":"b","sensorType":"humidity","value":2}]}';
     const parsed = parseSensorJson(malformed);
     expect(Array.isArray(parsed.sensors)).toBe(true);
     expect(parsed.sensors.length).toBe(2);
@@ -148,10 +148,10 @@ test('parseSensorJson fixes missing commas between sensor objects', () => {
 test('transformAggregatedData converts API response', () => {
     const raw = {
         sensors: [
-            { type: 'temperature', unit: '°C', data: [{ timestamp: '2025-07-25T09:00:04Z', value: 27.5 }] },
-            { type: 'humidity', unit: '%', data: [{ timestamp: '2025-07-25T09:00:04Z', value: 56 }] },
-            { type: 'light', unit: 'lux', data: [{ timestamp: '2025-07-25T09:00:04Z', value: 90 }] },
-            { type: 'colorSpectrum', unit: 'raw', data: [{ timestamp: '2025-07-25T09:00:04Z', value: { '415nm': 1, '445nm': 2, '480nm': 3, '515nm': 4, '555nm': 5, '590nm': 6, '630nm': 7, '680nm': 8, clear: 9, nir: 10 } }] }
+            { sensorType: 'temperature', unit: '°C', data: [{ timestamp: '2025-07-25T09:00:04Z', value: 27.5 }] },
+            { sensorType: 'humidity', unit: '%', data: [{ timestamp: '2025-07-25T09:00:04Z', value: 56 }] },
+            { sensorType: 'light', unit: 'lux', data: [{ timestamp: '2025-07-25T09:00:04Z', value: 90 }] },
+            { sensorType: 'colorSpectrum', unit: 'raw', data: [{ timestamp: '2025-07-25T09:00:04Z', value: { '415nm': 1, '445nm': 2, '480nm': 3, '515nm': 4, '555nm': 5, '590nm': 6, '630nm': 7, '680nm': 8, clear: 9, nir: 10 } }] }
         ]
     };
     const result = transformAggregatedData(raw);


### PR DESCRIPTION
## Summary
- Prefer `sensorType` when normalizing or aggregating sensor data, falling back to `valueType`.
- Read sensor type via `s.sensorType || s.valueType` in device table, notes, and reports.
- Update tests and mock data to use `sensorType`.

## Testing
- `npx vitest run --reporter=basic`

------
https://chatgpt.com/codex/tasks/task_e_689e4cae01e88328a8671c5bc5c1f7e2