### PR TITLE
Use compositeId as canonical device identifier

### DIFF
--- a/src/components/DeviceTable.jsx
+++ b/src/components/DeviceTable.jsx
@@ -12,8 +12,8 @@ function getCellColor(value, range) {
 }
 
 function DeviceTable({devices = {}}) {
-    const deviceIds = Object.keys(devices);
-    const allSensors = deviceIds.flatMap(id => devices[id].sensors || []);
+    const compositeIds = Object.keys(devices);
+    const allSensors = compositeIds.flatMap(id => devices[id].sensors || []);
     const measurementTypes = new Set();
     const measurementToSensorModel = {};
     const labelMapFromData = {};
@@ -61,7 +61,7 @@ function DeviceTable({devices = {}}) {
         const bandKey = spectralKeyMapFromData[measurementType];
         const rowColor = bandKey ? `${spectralColors[bandKey]}22` : undefined;
 
-        const cells = deviceIds.map(id => {
+        const cells = compositeIds.map(id => {
             const s = devices[id].sensors?.find(s => (s.sensorType || s.valueType) === measurementType);
             const value = s?.value;
             const unit = s?.unit || '';
@@ -85,9 +85,9 @@ function DeviceTable({devices = {}}) {
                     <th className={styles.sensorCell}>M_Type</th>
                     <th className={styles.modelCell}>Min</th>
                     <th className={styles.modelCell}>Max</th>
-                    {deviceIds.map(id => {
+                    {compositeIds.map(id => {
                         const dev = devices[id];
-                        const label = dev?.compositeId ?? id;
+                        const label = dev?.compositeId || id;
                         return <th key={id}>{label}</th>;
                     })}
                 </tr>
@@ -102,7 +102,7 @@ function DeviceTable({devices = {}}) {
                         <td style={{backgroundColor: row.rowColor}}>{row.range?.min ?? '-'}</td>
                         <td style={{backgroundColor: row.rowColor}}>{row.range?.max ?? '-'}</td>
                         {row.cells.map((cell, i) => (
-                            <td key={deviceIds[i]} style={{backgroundColor: cell.color}}>
+                            <td key={compositeIds[i]} style={{backgroundColor: cell.color}}>
                                 <div className={styles.cellWrapper}>
                                     <span className={`${styles.indicator} ${cell.ok ? styles.on : styles.off}`}></span>
                                     <span className={styles.cellValue}>{cell.display}</span>

--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -36,19 +36,19 @@ function SensorDashboard({ view, title = '' }) {
         const map = {};
         for (const [sysId, topicsObj] of Object.entries(deviceData || {})) {
             for (const [topicKey, devs] of Object.entries(topicsObj || {})) {
-                for (const [cid, payload] of Object.entries(devs || {})) {
+                for (const [compositeId, payload] of Object.entries(devs || {})) {
                     const baseId = payload?.deviceId;
                     const layer = payload?.layer?.layer || payload?.layer || null;
-                    if (!map[cid]) {
-                        map[cid] = {system: sysId, layer, baseId, topics: new Set([topicKey])};
+                    if (!map[compositeId]) {
+                        map[compositeId] = {system: sysId, layer, baseId, topics: new Set([topicKey])};
                     } else {
-                        map[cid].topics.add(topicKey);
+                        map[compositeId].topics.add(topicKey);
                     }
                 }
             }
         }
         return Object.fromEntries(
-            Object.entries(map).map(([cid, m]) => [cid, {
+            Object.entries(map).map(([compositeId, m]) => [compositeId, {
                 system: m.system,
                 layer: m.layer,
                 baseId: m.baseId,
@@ -81,9 +81,9 @@ function SensorDashboard({ view, title = '' }) {
 
     // 4) Filter available device IDs based on all active filters
     const filteredCompositeIds = useMemo(() => {
-        return availableCompositeIds.filter((id) => {
-            const meta = deviceMeta[id] || {};
-            const okDev = devFilter === ALL || id === devFilter;
+        return availableCompositeIds.filter((compositeId) => {
+            const meta = deviceMeta[compositeId] || {};
+            const okDev = devFilter === ALL || compositeId === devFilter;
             const okLay = layerFilter === ALL || meta.layer === layerFilter;
             const okSys = sysFilter === ALL || meta.system === sysFilter;
             const okTopic = topicFilter === ALL || (meta.topics || []).includes(topicFilter);
@@ -97,8 +97,8 @@ function SensorDashboard({ view, title = '' }) {
         for (const [topic, devs] of Object.entries(activeSystemTopics || {})) {
             if (topicFilter !== ALL && topic !== topicFilter) continue;
             out[topic] = Object.fromEntries(
-                Object.entries(devs || {}).filter(([cid]) =>
-                    filteredCompositeIds.includes(cid)
+                Object.entries(devs || {}).filter(([compositeId]) =>
+                    filteredCompositeIds.includes(compositeId)
                 )
             );
         }

--- a/src/components/dashboard/useLiveDevices.js
+++ b/src/components/dashboard/useLiveDevices.js
@@ -30,7 +30,7 @@ export function useLiveDevices(topics, activeSystem) {
         const baseId = payload.deviceId || "unknown";
         const systemId = payload.system || "unknown";
         const loc = payload.layer || payload.layer || payload.meta?.layer || "";
-        const compositeId = loc ? `${loc}${baseId}` : baseId;
+        const compositeId = payload.compositeId || (loc ? `${loc}${baseId}` : baseId);
 
         if (Array.isArray(payload.sensors)) {
             const normalized = normalizeSensorData(payload);

--- a/tests/useLiveDevices.test.jsx
+++ b/tests/useLiveDevices.test.jsx
@@ -77,3 +77,23 @@ test('merges controllers from multiple topics', () => {
   expect(valve.state).toBe('open');
   expect(pump.state).toBe('on');
 });
+
+test('uses provided compositeId when present', () => {
+  const { result } = renderHook(() => useLiveDevices([SENSOR_TOPIC], 'S01'));
+
+  act(() => {
+    global.__stompHandler(SENSOR_TOPIC, {
+      compositeId: 'C123',
+      deviceId: 'ignored',
+      layer: 'L99',
+      system: 'S01',
+      sensors: [
+        { sensorType: 'temperature', value: '22' },
+        { sensorType: 'humidity', value: '55' }
+      ]
+    });
+  });
+
+  expect(result.current.sensorData['C123'].temperature.value).toBe(22);
+  expect(result.current.sensorData['C123'].humidity.value).toBe(55);
+});


### PR DESCRIPTION
## Summary
- allow `useLiveDevices` to respect incoming `payload.compositeId`
- treat compositeId as canonical key in `DeviceTable` and related filtering in `SensorDashboard`
- cover compositeId override in `useLiveDevices` tests

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_689ec42698c88328ad8cb64ffee16d5e