### PR TITLE
Include oxygen pump actuator topic and test merging

### DIFF
--- a/src/components/dashboard/dashboard.constants.js
+++ b/src/components/dashboard/dashboard.constants.js
@@ -1,7 +1,13 @@
 export const SENSOR_TOPIC = "growSensors";
 export const LIVE_NOW_TOPIC = "live_now";
 // Topic list used for device-level streams; excludes aggregated `live_now` data
-export const topics = [SENSOR_TOPIC, "rootImages", "waterOutput", "waterTank"];
+export const topics = [
+  SENSOR_TOPIC,
+  "rootImages",
+  "waterOutput",
+  "waterTank",
+  "actuator/oxygenPump",
+];
 
 export const bandMap = {
   F1: "415nm",


### PR DESCRIPTION
## Summary
- add `actuator/oxygenPump` to device stream topics
- test `useLiveDevices` merging of actuator payloads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ec7e73bf08328a6114e63bab062ad