### PR TITLE
feat: surface actuator metrics in dashboard overview

### DIFF
--- a/src/hooks/useLiveNow.js
+++ b/src/hooks/useLiveNow.js
@@ -5,10 +5,21 @@ import {useStomp} from "./useStomp";
 /** Latest payload from topic: live_now */
 export function useLiveNow() {
     const [status, setStatus] = useState(null);
+
+    const normalize = (payload) => {
+        const out = {};
+        for (const [k, v] of Object.entries(payload || {})) {
+            const key = k.replace(/[\s_-]/g, "").toLowerCase();
+            out[key] = v;
+        }
+        return out;
+    };
+
     const handle = useCallback((_topic, data) => {
         console.log('[live_now] message:', data);
-        setStatus(data);
+        setStatus(normalize(data));
     }, []);
+
     useStomp("live_now", handle);
     return status;
 }

--- a/tests/SensorDashboardOverview.test.jsx
+++ b/tests/SensorDashboardOverview.test.jsx
@@ -37,7 +37,7 @@ test('overview items reflect live_now data', () => {
       humidity: { average: 50, deviceCount: 2 },
       temperature: { average: 25, deviceCount: 3 },
       dissolvedOxygen: { average: 8, deviceCount: 4 },
-      airpump: { average: 1, deviceCount: 5 },
+      'Air Pump': { average: 1, deviceCount: 5 },
     });
   });
 
@@ -46,5 +46,8 @@ test('overview items reflect live_now data', () => {
 
   const tempBox = screen.getByTitle('Temperature');
   expect(within(tempBox).getByText('25')).toBeInTheDocument();
+
+  const pumpBox = screen.getByTitle('Air Pump');
+  expect(within(pumpBox).getByText('On')).toBeInTheDocument();
 });
 

--- a/tests/useLiveNow.test.jsx
+++ b/tests/useLiveNow.test.jsx
@@ -9,12 +9,13 @@ vi.mock('../src/hooks/useStomp', () => ({
   }
 }));
 
-test('captures live_now updates', () => {
+test('captures live_now updates and normalizes keys', () => {
   const { result } = renderHook(() => useLiveNow());
 
   act(() => {
-    global.__liveNowHandler('live_now', { ok: true });
+    global.__liveNowHandler('live_now', { 'Air Pump': { average: 1 }, Light: { average: 2 } });
   });
 
-  expect(result.current).toEqual({ ok: true });
+  expect(result.current).toHaveProperty('airpump');
+  expect(result.current).toHaveProperty('light');
 });


### PR DESCRIPTION
## Summary
- normalize `live_now` payload keys for case-insensitive lookup
- render controller metrics (e.g. air pump) in dashboard overview
- test actuator metrics and key normalization

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ecf87717c832886750c737c0b8c8b