### PR TITLE
feat: show layer water and actuator metrics

### DIFF
--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -62,14 +62,17 @@ function normalizeLiveNow(payload) {
             const {avg: lux, count: lightCount} = getMetric(env, "light");
             const {avg: temp, count: tempCount} = getMetric(env, "temperature");
             const {avg: humidity, count: humidityCount} = getMetric(env, "humidity");
+
+            const {avg: dTemp, count: dTempCount} = getMetric(water, "dissolvedTemp");
             const {avg: DO, count: DOCount} = getMetric(water, "dissolvedOxygen");
-            const {avg: airPumpAvg, count: airPumpCount} = getMetric(
-                acts,
-                "airpump"
-            );
+            const {avg: pH, count: pHCount} = getMetric(water, "pH", "ph");
+            const {avg: EC, count: ECCount} = getMetric(water, "dissolvedEC");
+            const {avg: TDS, count: TDSCount} = getMetric(water, "dissolvedTDS");
+
+            const {avg: airPumpAvg, count: airPumpCount} = getMetric(acts, "airpump");
             const airPump = airPumpAvg == null ? null : airPumpAvg >= 0.5;
 
-            const hasAny = [lux, temp, humidity, DO, airPumpAvg].some(
+            const hasAny = [lux, temp, humidity, dTemp, DO, pH, EC, TDS, airPumpAvg].some(
                 (v) => v != null
             );
             const missingEnv = [lux, temp, humidity].some((v) => v == null);
@@ -89,9 +92,22 @@ function normalizeLiveNow(payload) {
                     },
                 },
                 water: {
-                    DO: DO ?? null,
+                    dissolvedTemp: dTemp ?? null,
+                    dissolvedOxygen: DO ?? null,
+                    pH: pH ?? null,
+                    dissolvedEC: EC ?? null,
+                    dissolvedTDS: TDS ?? null,
+                    _counts: {
+                        dissolvedTemp: dTempCount,
+                        dissolvedOxygen: DOCount,
+                        pH: pHCount,
+                        dissolvedEC: ECCount,
+                        dissolvedTDS: TDSCount,
+                    },
+                },
+                actuators: {
                     airPump,
-                    _counts: {DO: DOCount, airPump: airPumpCount},
+                    _counts: { airPump: airPumpCount },
                 },
             });
         }
@@ -201,6 +217,8 @@ export default function DashboardPage() {
                                 id={l.id}
                                 health={l.health}
                                 metrics={{...l.metrics, _counts: l.metrics?._counts}}
+                                water={{...l.water, _counts: l.water?._counts}}
+                                actuators={{...l.actuators, _counts: l.actuators?._counts}}
                             />
                         ))}
                     </div>

--- a/src/pages/SystemAndLayerCards.jsx
+++ b/src/pages/SystemAndLayerCards.jsx
@@ -47,9 +47,9 @@ function Pill({label, health}) {
 
 /* ========== Metric Card ========== */
 // کارت با استایل شبیه تصویر (آیکن، عدد بزرگ، عنوان، زیرنویس)
-export function MetricCard({ title, value, unit, icon, subtitle }) {
+export function MetricCard({ title, value, unit, icon, subtitle, compact }) {
     return (
-        <div className={cx("metric-card-neo")}>
+        <div className={cx("metric-card-neo", compact && "compact")}>
             <div className={cx("metric-row-top")}>
                 <div className={cx("metric-icon-lg")}>{icon}</div>
                 <div className={cx("metric-reading")}>
@@ -127,7 +127,7 @@ export function SystemOverviewCard({
 }
 
 /* ========== Layer Panel ========== */
-export function LayerPanel({id, health, metrics, children}) {
+export function LayerPanel({id, health, metrics, water = {}, actuators = {}, children}) {
     return (
         <div className={cx("layer-card")}>
             <div className={cx("layer-head")}>
@@ -135,12 +135,23 @@ export function LayerPanel({id, health, metrics, children}) {
                 <span className={cx("layer-title")}>Layer {id}</span>
             </div>
 
-            <div className="metrics-row three">
-                <MetricCard title="Light"       value={fmt(metrics.lux, 1)} unit="lx"  icon={<span>☀️</span>}  subtitle={metrics?._counts?.light != null ? `Composite IDs: ${metrics._counts.light}` : undefined} />
-                <MetricCard title="Temperature" value={fmt(metrics.temp, 1)} unit="°C" icon={<span>🌡️</span>}  subtitle={metrics?._counts?.temperature != null ? `Composite IDs: ${metrics._counts.temperature}` : undefined} />
-                <MetricCard title="Humidity"    value={fmt(metrics.humidity, 1)} unit="%" icon={<span>%</span>} subtitle={metrics?._counts?.humidity != null ? `Composite IDs: ${metrics._counts.humidity}` : undefined} />
+            <div className={cx("metrics-row", "three")}>
+                <MetricCard compact title="Light" value={fmt(metrics.lux, 1)} unit="lx" icon={<span>☀️</span>} subtitle={metrics?._counts?.light != null ? `Composite IDs: ${metrics._counts.light}` : undefined} />
+                <MetricCard compact title="Temperature" value={fmt(metrics.temp, 1)} unit="°C" icon={<span>🌡️</span>} subtitle={metrics?._counts?.temperature != null ? `Composite IDs: ${metrics._counts.temperature}` : undefined} />
+                <MetricCard compact title="Humidity" value={fmt(metrics.humidity, 1)} unit="%" icon={<span>%</span>} subtitle={metrics?._counts?.humidity != null ? `Composite IDs: ${metrics._counts.humidity}` : undefined} />
             </div>
 
+            <div className={cx("metrics-row", "three")}>
+                <MetricCard compact title="Water Temp" value={fmt(water.dissolvedTemp, 1)} unit="°C" icon={<span>🌡️</span>} subtitle={water?._counts?.dissolvedTemp != null ? `Composite IDs: ${water._counts.dissolvedTemp}` : undefined} />
+                <MetricCard compact title="DO" value={fmt(water.dissolvedOxygen, 1)} unit="mg/L" icon={<span>O₂</span>} subtitle={water?._counts?.dissolvedOxygen != null ? `Composite IDs: ${water._counts.dissolvedOxygen}` : undefined} />
+                <MetricCard compact title="pH" value={fmt(water.pH, 1)} icon={<span>⚗️</span>} subtitle={water?._counts?.pH != null ? `Composite IDs: ${water._counts.pH}` : undefined} />
+            </div>
+
+            <div className={cx("metrics-row", "three")}>
+                <MetricCard compact title="EC" value={fmt(water.dissolvedEC, 2)} unit="mS/cm" icon={<span>📈</span>} subtitle={water?._counts?.dissolvedEC != null ? `Composite IDs: ${water._counts.dissolvedEC}` : undefined} />
+                <MetricCard compact title="TDS" value={fmt(water.dissolvedTDS, 0)} unit="ppm" icon={<span>💧</span>} subtitle={water?._counts?.dissolvedTDS != null ? `Composite IDs: ${water._counts.dissolvedTDS}` : undefined} />
+                <MetricCard compact title="Air Pump" value={actuators.airPump ? "On" : "Off"} icon={<span>🫧</span>} subtitle={actuators?._counts?.airPump != null ? `Composite IDs: ${actuators._counts.airPump}` : undefined} />
+            </div>
 
             {children ? <div className={cx("layer-children")}>{children}</div> : null}
         </div>


### PR DESCRIPTION
## Summary
- extend `LayerPanel` to render water metrics and actuator status in compact layout
- parse layer water and actuator data in `DashboardPage` and pass into `LayerPanel`
- allow `MetricCard` to render in compact mode for tight layer cards

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f6c347e648328af64d0a5344c9569