### PR TITLE
Display metrics in single row

### DIFF
--- a/src/pages/SystemAndLayerCards.jsx
+++ b/src/pages/SystemAndLayerCards.jsx
@@ -108,19 +108,16 @@ export function SystemOverviewCard({
                 </div>
             </div>
 
-            <div className={cx("metrics-row", "three")}> 
-                <MetricCard title="Light" value={fmt(metrics.light, 1)} unit="lux" icon={<span>☀️</span>} subtitle={metrics?._counts?.light != null ? `Composite IDs: ${metrics._counts.light}` : undefined} />
-                <MetricCard title="Humidity" value={fmt(metrics.humidity, 1)} unit="%" icon={<span>%</span>} subtitle={metrics?._counts?.humidity != null ? `Composite IDs: ${metrics._counts.humidity}` : undefined} />
-                <MetricCard title="Air Temp" value={fmt(metrics.airTemperature, 1)} unit="°C" icon={<span>🌡️</span>} subtitle={metrics?._counts?.airTemperature != null ? `Composite IDs: ${metrics._counts.airTemperature}` : undefined} />
-            </div>
-
-            <div className={cx("metrics-row")}> 
-                <MetricCard title="Water Temp" value={fmt(metrics.dissolvedTemp, 1)} unit="°C" icon={<span>🌡️</span>} subtitle={metrics?._counts?.dissolvedTemp != null ? `Composite IDs: ${metrics._counts.dissolvedTemp}` : undefined} />
-                <MetricCard title="DO" value={fmt(metrics.dissolvedOxygen, 1)} unit="mg/L" icon={<span>O₂</span>} subtitle={metrics?._counts?.dissolvedOxygen != null ? `Composite IDs: ${metrics._counts.dissolvedOxygen}` : undefined} />
-                <MetricCard title="EC" value={fmt(metrics.dissolvedEC, 2)} unit="mS/cm" icon={<span>📈</span>} subtitle={metrics?._counts?.dissolvedEC != null ? `Composite IDs: ${metrics._counts.dissolvedEC}` : undefined} />
-                <MetricCard title="TDS" value={fmt(metrics.dissolvedTDS, 0)} unit="ppm" icon={<span>💧</span>} subtitle={metrics?._counts?.dissolvedTDS != null ? `Composite IDs: ${metrics._counts.dissolvedTDS}` : undefined} />
-                <MetricCard title="pH" value={fmt(metrics.pH, 1)} icon={<span>⚗️</span>} subtitle={metrics?._counts?.pH != null ? `Composite IDs: ${metrics._counts.pH}` : undefined} />
-                <MetricCard title="Air Pump" value={metrics.airPump ? "On" : "Off"} icon={<span>🫧</span>} subtitle={metrics?._counts?.airPump != null ? `Composite IDs: ${metrics._counts.airPump}` : undefined} />
+            <div className={cx("metrics-row")}>
+                <MetricCard compact title="Light" value={fmt(metrics.light, 1)} unit="lux" icon={<span>☀️</span>} subtitle={metrics?._counts?.light != null ? `Composite IDs: ${metrics._counts.light}` : undefined} />
+                <MetricCard compact title="Humidity" value={fmt(metrics.humidity, 1)} unit="%" icon={<span>%</span>} subtitle={metrics?._counts?.humidity != null ? `Composite IDs: ${metrics._counts.humidity}` : undefined} />
+                <MetricCard compact title="Air Temp" value={fmt(metrics.airTemperature, 1)} unit="°C" icon={<span>🌡️</span>} subtitle={metrics?._counts?.airTemperature != null ? `Composite IDs: ${metrics._counts.airTemperature}` : undefined} />
+                <MetricCard compact title="Water Temp" value={fmt(metrics.dissolvedTemp, 1)} unit="°C" icon={<span>🌡️</span>} subtitle={metrics?._counts?.dissolvedTemp != null ? `Composite IDs: ${metrics._counts.dissolvedTemp}` : undefined} />
+                <MetricCard compact title="DO" value={fmt(metrics.dissolvedOxygen, 1)} unit="mg/L" icon={<span>O₂</span>} subtitle={metrics?._counts?.dissolvedOxygen != null ? `Composite IDs: ${metrics._counts.dissolvedOxygen}` : undefined} />
+                <MetricCard compact title="EC" value={fmt(metrics.dissolvedEC, 2)} unit="mS/cm" icon={<span>📈</span>} subtitle={metrics?._counts?.dissolvedEC != null ? `Composite IDs: ${metrics._counts.dissolvedEC}` : undefined} />
+                <MetricCard compact title="TDS" value={fmt(metrics.dissolvedTDS, 0)} unit="ppm" icon={<span>💧</span>} subtitle={metrics?._counts?.dissolvedTDS != null ? `Composite IDs: ${metrics._counts.dissolvedTDS}` : undefined} />
+                <MetricCard compact title="pH" value={fmt(metrics.pH, 1)} icon={<span>⚗️</span>} subtitle={metrics?._counts?.pH != null ? `Composite IDs: ${metrics._counts.pH}` : undefined} />
+                <MetricCard compact title="Air Pump" value={metrics.airPump ? "On" : "Off"} icon={<span>🫧</span>} subtitle={metrics?._counts?.airPump != null ? `Composite IDs: ${metrics._counts.airPump}` : undefined} />
             </div>
         </div>
     );
@@ -135,19 +132,13 @@ export function LayerPanel({id, health, metrics, water = {}, actuators = {}, chi
                 <span className={cx("layer-title")}>Layer {id}</span>
             </div>
 
-            <div className={cx("metrics-row", "three")}>
+            <div className={cx("metrics-row")}>
                 <MetricCard compact title="Light" value={fmt(metrics.lux, 1)} unit="lx" icon={<span>☀️</span>} subtitle={metrics?._counts?.light != null ? `Composite IDs: ${metrics._counts.light}` : undefined} />
                 <MetricCard compact title="Temperature" value={fmt(metrics.temp, 1)} unit="°C" icon={<span>🌡️</span>} subtitle={metrics?._counts?.temperature != null ? `Composite IDs: ${metrics._counts.temperature}` : undefined} />
                 <MetricCard compact title="Humidity" value={fmt(metrics.humidity, 1)} unit="%" icon={<span>%</span>} subtitle={metrics?._counts?.humidity != null ? `Composite IDs: ${metrics._counts.humidity}` : undefined} />
-            </div>
-
-            <div className={cx("metrics-row", "three")}>
                 <MetricCard compact title="Water Temp" value={fmt(water.dissolvedTemp, 1)} unit="°C" icon={<span>🌡️</span>} subtitle={water?._counts?.dissolvedTemp != null ? `Composite IDs: ${water._counts.dissolvedTemp}` : undefined} />
                 <MetricCard compact title="DO" value={fmt(water.dissolvedOxygen, 1)} unit="mg/L" icon={<span>O₂</span>} subtitle={water?._counts?.dissolvedOxygen != null ? `Composite IDs: ${water._counts.dissolvedOxygen}` : undefined} />
                 <MetricCard compact title="pH" value={fmt(water.pH, 1)} icon={<span>⚗️</span>} subtitle={water?._counts?.pH != null ? `Composite IDs: ${water._counts.pH}` : undefined} />
-            </div>
-
-            <div className={cx("metrics-row", "three")}>
                 <MetricCard compact title="EC" value={fmt(water.dissolvedEC, 2)} unit="mS/cm" icon={<span>📈</span>} subtitle={water?._counts?.dissolvedEC != null ? `Composite IDs: ${water._counts.dissolvedEC}` : undefined} />
                 <MetricCard compact title="TDS" value={fmt(water.dissolvedTDS, 0)} unit="ppm" icon={<span>💧</span>} subtitle={water?._counts?.dissolvedTDS != null ? `Composite IDs: ${water._counts.dissolvedTDS}` : undefined} />
                 <MetricCard compact title="Air Pump" value={actuators.airPump ? "On" : "Off"} icon={<span>🫧</span>} subtitle={actuators?._counts?.airPump != null ? `Composite IDs: ${actuators._counts.airPump}` : undefined} />

--- a/src/pages/SystemAndLayerCards.module.css
+++ b/src/pages/SystemAndLayerCards.module.css
@@ -97,8 +97,13 @@
 .sys-section{ margin-top:12px; }
 .layers-row{ display:flex; flex-wrap:wrap; gap:8px; margin-top:6px; }
 
-.metrics-row{ margin-top:14px; display:grid; grid-template-columns: repeat(5, minmax(0,1fr)); gap:12px; }
-.metrics-row.three{ grid-template-columns: repeat(3, minmax(0,1fr)); }
+.metrics-row{
+  margin-top:14px;
+  display:grid;
+  grid-auto-flow:column;
+  grid-auto-columns:minmax(0,1fr);
+  gap:12px;
+}
 
 .metric-bottom{ margin-top:8px; }
 


### PR DESCRIPTION
## Summary
- Place all system and layer metrics in single rows with compact MetricCards
- Use a flexible grid layout so cards shrink to fit one line

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a00fe4dad48328a5edef145ca62bdf