### PR TITLE
Rename air temperature metric to temperature

### DIFF
--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -118,9 +118,9 @@ export function normalizeLiveNow(payload) {
         const sysEnv = sys.environment ?? {};
         const {avg: lightAvg, count: lightCount} = getMetric(sysEnv, "light");
         const {avg: humidityAvg, count: humidityCount} = getMetric(sysEnv, "humidity");
-        const {avg: airTempAvg, count: airTempCount} = getMetric(
+        const {avg: tempAvg, count: tempCount} = getMetric(
             sysEnv,
-            "airTemperature"
+            "temperature"
         );
 
         const sysWater = sys.water ?? {};
@@ -162,7 +162,7 @@ export function normalizeLiveNow(payload) {
             metrics: {
                 light: lightAvg ?? null,
                 humidity: humidityAvg ?? null,
-                airTemperature: airTempAvg ?? null,
+                temperature: tempAvg ?? null,
                 dissolvedTemp: dTempAvg ?? null,
                 dissolvedOxygen: DOavg ?? null,
                 dissolvedEC: ECavg ?? null,
@@ -172,7 +172,7 @@ export function normalizeLiveNow(payload) {
                 _counts: {
                     light: lightCount,
                     humidity: humidityCount,
-                    airTemperature: airTempCount,
+                    temperature: tempCount,
                     dissolvedTemp: dTempCount,
                     dissolvedOxygen: DOcount,
                     dissolvedEC: ECcount,

--- a/src/pages/SystemAndLayerCards.jsx
+++ b/src/pages/SystemAndLayerCards.jsx
@@ -111,7 +111,7 @@ export function SystemOverviewCard({
             <div className={cx("metrics-row")}>
                 <MetricCard compact title="Light" value={fmt(metrics.light, 1)} unit="lux" icon={<span>☀️</span>} subtitle={metrics?._counts?.light != null ? `Composite IDs: ${metrics._counts.light}` : undefined} />
                 <MetricCard compact title="Humidity" value={fmt(metrics.humidity, 1)} unit="%" icon={<span>%</span>} subtitle={metrics?._counts?.humidity != null ? `Composite IDs: ${metrics._counts.humidity}` : undefined} />
-                <MetricCard compact title="Air Temp" value={fmt(metrics.airTemperature, 1)} unit="°C" icon={<span>🌡️</span>} subtitle={metrics?._counts?.airTemperature != null ? `Composite IDs: ${metrics._counts.airTemperature}` : undefined} />
+                <MetricCard compact title="Temperature" value={fmt(metrics.temperature, 1)} unit="°C" icon={<span>🌡️</span>} subtitle={metrics?._counts?.temperature != null ? `Composite IDs: ${metrics._counts.temperature}` : undefined} />
                 <MetricCard compact title="Water Temp" value={fmt(metrics.dissolvedTemp, 1)} unit="°C" icon={<span>🌡️</span>} subtitle={metrics?._counts?.dissolvedTemp != null ? `Composite IDs: ${metrics._counts.dissolvedTemp}` : undefined} />
                 <MetricCard compact title="DO" value={fmt(metrics.dissolvedOxygen, 1)} unit="mg/L" icon={<span>O₂</span>} subtitle={metrics?._counts?.dissolvedOxygen != null ? `Composite IDs: ${metrics._counts.dissolvedOxygen}` : undefined} />
                 <MetricCard compact title="EC" value={fmt(metrics.dissolvedEC, 2)} unit="mS/cm" icon={<span>📈</span>} subtitle={metrics?._counts?.dissolvedEC != null ? `Composite IDs: ${metrics._counts.dissolvedEC}` : undefined} />

--- a/tests/DashboardNormalize.test.jsx
+++ b/tests/DashboardNormalize.test.jsx
@@ -15,7 +15,7 @@ const samplePayload = {
       environment: {
         light: { average: 12, deviceCount: 1 },
         humidity: { average: 55, deviceCount: 1 },
-        airTemperature: { average: 25, deviceCount: 1 }
+        temperature: { average: 25, deviceCount: 1 }
       },
       water: {
         dissolvedTemp: { average: 20, deviceCount: 1 },
@@ -67,7 +67,7 @@ describe('normalizeLiveNow', () => {
     // system-level metrics
     expect(sys.metrics.light).toBe(12);
     expect(sys.metrics.humidity).toBe(55);
-    expect(sys.metrics.airTemperature).toBe(25);
+    expect(sys.metrics.temperature).toBe(25);
     expect(sys.metrics.airPump).toBe(true);
     expect(sys.metrics._counts.light).toBe(1);
     // layer summary counts


### PR DESCRIPTION
## Summary
- rename Air Temp metric to Temperature for systems
- adjust UI label and metrics mapping
- update normalization test for new temperature key

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a03c0d614c8328a80e89b9cb9e7edc