### PR TITLE
Switch history endpoint to records API

### DIFF
--- a/src/components/dashboard/useHistory.js
+++ b/src/components/dashboard/useHistory.js
@@ -1,7 +1,7 @@
 import {useCallback, useEffect, useRef, useState} from "react";
 import {transformAggregatedData} from "../../utils";
 
-export function useHistory(espId, from, to, autoRefresh, interval) {
+export function useHistory(compositeId, from, to, autoRefresh, interval) {
     const [rangeData, setRangeData] = useState([]);
     const [tempRangeData, setTempRangeData] = useState([]);
     const [phRangeData, setPhRangeData] = useState([]);
@@ -20,11 +20,11 @@ export function useHistory(espId, from, to, autoRefresh, interval) {
     useEffect(() => { startTimeRef.current = startTime; }, [startTime]);
 
     const fetchReportData = useCallback(async () => {
-        if (!from || !to || !espId) return;
+        if (!from || !to || !compositeId) return;
         try {
             const fromIso = new Date(from).toISOString();
             const toIso = new Date(to).toISOString();
-            const url = `https://api.hydroleaf.se/api/sensors/history/aggregated?espId=${espId}&from=${fromIso}&to=${toIso}`;
+            const url = `https://api.hydroleaf.se/api/records/history/aggregated?compositeId=${compositeId}&from=${fromIso}&to=${toIso}`;
             const res = await fetch(url);
             if (!res.ok) throw new Error("bad response");
             const json = await res.json();
@@ -52,14 +52,14 @@ export function useHistory(espId, from, to, autoRefresh, interval) {
         } catch (e) {
             console.error("Failed to fetch history", e);
         }
-    }, [espId, from, to]);
+    }, [compositeId, from, to]);
 
     const fetchNewData = useCallback(async () => {
         try {
             const fromIso = new Date(endTimeRef.current).toISOString();
             const nowDate = new Date();
             const toIso = nowDate.toISOString();
-            const url = `https://api.hydroleaf.se/api/sensors/history/aggregated?espId=${espId}&from=${fromIso}&to=${toIso}`;
+            const url = `https://api.hydroleaf.se/api/records/history/aggregated?compositeId=${compositeId}&from=${fromIso}&to=${toIso}`;
             const res = await fetch(url);
             if (!res.ok) throw new Error("bad response");
             const json = await res.json();
@@ -89,7 +89,7 @@ export function useHistory(espId, from, to, autoRefresh, interval) {
         } catch (e) {
             console.error("Failed to fetch history", e);
         }
-    }, [espId]);
+    }, [compositeId]);
 
     useEffect(() => {
         fetchReportData();

--- a/src/pages/ReportsPage.jsx
+++ b/src/pages/ReportsPage.jsx
@@ -104,17 +104,6 @@ function ReportsPage() {
         }
     }, [filteredCompositeIds, selectedDevice]);
 
-    // Determine base device ID for history lookup
-    const selectedBaseId = useMemo(() => {
-        const sysTopics = deviceData[activeSystem] || {};
-        for (const topicDevices of Object.values(sysTopics)) {
-            if (selectedDevice in topicDevices) {
-                return topicDevices[selectedDevice].deviceId || selectedDevice;
-            }
-        }
-        return selectedDevice;
-    }, [deviceData, activeSystem, selectedDevice]);
-
     const {
         rangeData = [],
         tempRangeData = [],
@@ -125,7 +114,7 @@ function ReportsPage() {
         startTime = 0,
         endTime = 0,
         fetchReportData = () => {},
-    } = useHistory(selectedBaseId, fromDate, toDate, autoRefresh, refreshInterval);
+    } = useHistory(selectedDevice, fromDate, toDate, autoRefresh, refreshInterval);
 
     // Determine which report sections to display
     const sensorTypesForSelected = useMemo(() => {


### PR DESCRIPTION
## Summary
- fetch historical reports from `records` API using `compositeId`
- drop base ID mapping and pass selected composite ID to history hook

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0675a903c8328a5bd608a72ea9acc