### PR TITLE
Handle Sidebar collapsed state based on viewport width

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,11 +1,21 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { NavLink } from "react-router-dom";
 import styles from "./Sidebar.module.css";
 import { useFilters, ALL } from "../context/FiltersContext";
 
 export default function Sidebar() {
-    const [collapsed, setCollapsed] = useState(false);
+    const [collapsed, setCollapsed] = useState(() => window.innerWidth < 768);
     const { device, layer, system, topic, setDevice, setLayer, setSystem, setTopic, lists } = useFilters();
+
+    useEffect(() => {
+        const handleResize = () => {
+            const shouldCollapse = window.innerWidth < 768;
+            setCollapsed((prev) => (prev === shouldCollapse ? prev : shouldCollapse));
+        };
+
+        window.addEventListener("resize", handleResize);
+        return () => window.removeEventListener("resize", handleResize);
+    }, []);
 
     const linkClass = ({ isActive }) =>
         `${styles.menuItem} ${isActive ? styles.active : ""}`;


### PR DESCRIPTION
## Summary
- collapse sidebar when viewport is <768px and expand otherwise
- keep sidebar state in sync with window resize

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a07e7172a883289fb9efacde20b10c