### PR TITLE
feat: arrange metrics in two rows on mobile

### DIFF
--- a/src/pages/SystemAndLayerCards.jsx
+++ b/src/pages/SystemAndLayerCards.jsx
@@ -108,16 +108,20 @@ export function SystemOverviewCard({
                 </div>
             </div>
 
-            <div className={cx("metrics-row")}>
-                <MetricCard compact title="Light" value={fmt(metrics.light, 1)} unit="lux" icon={<span>☀️</span>} subtitle={metrics?._counts?.light != null ? `Composite IDs: ${metrics._counts.light}` : undefined} />
-                <MetricCard compact title="Humidity" value={fmt(metrics.humidity, 1)} unit="%" icon={<span>%</span>} subtitle={metrics?._counts?.humidity != null ? `Composite IDs: ${metrics._counts.humidity}` : undefined} />
-                <MetricCard compact title="Temperature" value={fmt(metrics.temperature, 1)} unit="°C" icon={<span>🌡️</span>} subtitle={metrics?._counts?.temperature != null ? `Composite IDs: ${metrics._counts.temperature}` : undefined} />
-                <MetricCard compact title="Water Temp" value={fmt(metrics.dissolvedTemp, 1)} unit="°C" icon={<span>🌡️</span>} subtitle={metrics?._counts?.dissolvedTemp != null ? `Composite IDs: ${metrics._counts.dissolvedTemp}` : undefined} />
-                <MetricCard compact title="DO" value={fmt(metrics.dissolvedOxygen, 1)} unit="mg/L" icon={<span>O₂</span>} subtitle={metrics?._counts?.dissolvedOxygen != null ? `Composite IDs: ${metrics._counts.dissolvedOxygen}` : undefined} />
-                <MetricCard compact title="EC" value={fmt(metrics.dissolvedEC, 2)} unit="mS/cm" icon={<span>📈</span>} subtitle={metrics?._counts?.dissolvedEC != null ? `Composite IDs: ${metrics._counts.dissolvedEC}` : undefined} />
-                <MetricCard compact title="TDS" value={fmt(metrics.dissolvedTDS, 0)} unit="ppm" icon={<span>💧</span>} subtitle={metrics?._counts?.dissolvedTDS != null ? `Composite IDs: ${metrics._counts.dissolvedTDS}` : undefined} />
-                <MetricCard compact title="pH" value={fmt(metrics.pH, 1)} icon={<span>⚗️</span>} subtitle={metrics?._counts?.pH != null ? `Composite IDs: ${metrics._counts.pH}` : undefined} />
-                <MetricCard compact title="Air Pump" value={metrics.airPump ? "On" : "Off"} icon={<span>🫧</span>} subtitle={metrics?._counts?.airPump != null ? `Composite IDs: ${metrics._counts.airPump}` : undefined} />
+            <div className={cx("metrics-row")}> 
+                <div className={cx("metrics-group")}> 
+                    <MetricCard compact title="Water Temp" value={fmt(metrics.dissolvedTemp, 1)} unit="°C" icon={<span>🌡️</span>} subtitle={metrics?._counts?.dissolvedTemp != null ? `Composite IDs: ${metrics._counts.dissolvedTemp}` : undefined} />
+                    <MetricCard compact title="DO" value={fmt(metrics.dissolvedOxygen, 1)} unit="mg/L" icon={<span>O₂</span>} subtitle={metrics?._counts?.dissolvedOxygen != null ? `Composite IDs: ${metrics._counts.dissolvedOxygen}` : undefined} />
+                    <MetricCard compact title="EC" value={fmt(metrics.dissolvedEC, 2)} unit="mS/cm" icon={<span>📈</span>} subtitle={metrics?._counts?.dissolvedEC != null ? `Composite IDs: ${metrics._counts.dissolvedEC}` : undefined} />
+                    <MetricCard compact title="TDS" value={fmt(metrics.dissolvedTDS, 0)} unit="ppm" icon={<span>💧</span>} subtitle={metrics?._counts?.dissolvedTDS != null ? `Composite IDs: ${metrics._counts.dissolvedTDS}` : undefined} />
+                    <MetricCard compact title="pH" value={fmt(metrics.pH, 1)} icon={<span>⚗️</span>} subtitle={metrics?._counts?.pH != null ? `Composite IDs: ${metrics._counts.pH}` : undefined} />
+                    <MetricCard compact title="Air Pump" value={metrics.airPump ? "On" : "Off"} icon={<span>🫧</span>} subtitle={metrics?._counts?.airPump != null ? `Composite IDs: ${metrics._counts.airPump}` : undefined} />
+                </div>
+                <div className={cx("metrics-group")}> 
+                    <MetricCard compact title="Light" value={fmt(metrics.light, 1)} unit="lux" icon={<span>☀️</span>} subtitle={metrics?._counts?.light != null ? `Composite IDs: ${metrics._counts.light}` : undefined} />
+                    <MetricCard compact title="Humidity" value={fmt(metrics.humidity, 1)} unit="%" icon={<span>%</span>} subtitle={metrics?._counts?.humidity != null ? `Composite IDs: ${metrics._counts.humidity}` : undefined} />
+                    <MetricCard compact title="Temperature" value={fmt(metrics.temperature, 1)} unit="°C" icon={<span>🌡️</span>} subtitle={metrics?._counts?.temperature != null ? `Composite IDs: ${metrics._counts.temperature}` : undefined} />
+                </div>
             </div>
         </div>
     );
@@ -132,16 +136,20 @@ export function LayerPanel({id, health, metrics, water = {}, actuators = {}, chi
                 <span className={cx("layer-title")}>Layer {id}</span>
             </div>
 
-            <div className={cx("metrics-row")}>
-                <MetricCard compact title="Light" value={fmt(metrics.lux, 1)} unit="lx" icon={<span>☀️</span>} subtitle={metrics?._counts?.light != null ? `Composite IDs: ${metrics._counts.light}` : undefined} />
-                <MetricCard compact title="Temperature" value={fmt(metrics.temp, 1)} unit="°C" icon={<span>🌡️</span>} subtitle={metrics?._counts?.temperature != null ? `Composite IDs: ${metrics._counts.temperature}` : undefined} />
-                <MetricCard compact title="Humidity" value={fmt(metrics.humidity, 1)} unit="%" icon={<span>%</span>} subtitle={metrics?._counts?.humidity != null ? `Composite IDs: ${metrics._counts.humidity}` : undefined} />
-                <MetricCard compact title="Water Temp" value={fmt(water.dissolvedTemp, 1)} unit="°C" icon={<span>🌡️</span>} subtitle={water?._counts?.dissolvedTemp != null ? `Composite IDs: ${water._counts.dissolvedTemp}` : undefined} />
-                <MetricCard compact title="DO" value={fmt(water.dissolvedOxygen, 1)} unit="mg/L" icon={<span>O₂</span>} subtitle={water?._counts?.dissolvedOxygen != null ? `Composite IDs: ${water._counts.dissolvedOxygen}` : undefined} />
-                <MetricCard compact title="pH" value={fmt(water.pH, 1)} icon={<span>⚗️</span>} subtitle={water?._counts?.pH != null ? `Composite IDs: ${water._counts.pH}` : undefined} />
-                <MetricCard compact title="EC" value={fmt(water.dissolvedEC, 2)} unit="mS/cm" icon={<span>📈</span>} subtitle={water?._counts?.dissolvedEC != null ? `Composite IDs: ${water._counts.dissolvedEC}` : undefined} />
-                <MetricCard compact title="TDS" value={fmt(water.dissolvedTDS, 0)} unit="ppm" icon={<span>💧</span>} subtitle={water?._counts?.dissolvedTDS != null ? `Composite IDs: ${water._counts.dissolvedTDS}` : undefined} />
-                <MetricCard compact title="Air Pump" value={actuators.airPump ? "On" : "Off"} icon={<span>🫧</span>} subtitle={actuators?._counts?.airPump != null ? `Composite IDs: ${actuators._counts.airPump}` : undefined} />
+            <div className={cx("metrics-row")}> 
+                <div className={cx("metrics-group")}> 
+                    <MetricCard compact title="Water Temp" value={fmt(water.dissolvedTemp, 1)} unit="°C" icon={<span>🌡️</span>} subtitle={water?._counts?.dissolvedTemp != null ? `Composite IDs: ${water._counts.dissolvedTemp}` : undefined} />
+                    <MetricCard compact title="DO" value={fmt(water.dissolvedOxygen, 1)} unit="mg/L" icon={<span>O₂</span>} subtitle={water?._counts?.dissolvedOxygen != null ? `Composite IDs: ${water._counts.dissolvedOxygen}` : undefined} />
+                    <MetricCard compact title="pH" value={fmt(water.pH, 1)} icon={<span>⚗️</span>} subtitle={water?._counts?.pH != null ? `Composite IDs: ${water._counts.pH}` : undefined} />
+                    <MetricCard compact title="EC" value={fmt(water.dissolvedEC, 2)} unit="mS/cm" icon={<span>📈</span>} subtitle={water?._counts?.dissolvedEC != null ? `Composite IDs: ${water._counts.dissolvedEC}` : undefined} />
+                    <MetricCard compact title="TDS" value={fmt(water.dissolvedTDS, 0)} unit="ppm" icon={<span>💧</span>} subtitle={water?._counts?.dissolvedTDS != null ? `Composite IDs: ${water._counts.dissolvedTDS}` : undefined} />
+                    <MetricCard compact title="Air Pump" value={actuators.airPump ? "On" : "Off"} icon={<span>🫧</span>} subtitle={actuators?._counts?.airPump != null ? `Composite IDs: ${actuators._counts.airPump}` : undefined} />
+                </div>
+                <div className={cx("metrics-group")}> 
+                    <MetricCard compact title="Light" value={fmt(metrics.lux, 1)} unit="lx" icon={<span>☀️</span>} subtitle={metrics?._counts?.light != null ? `Composite IDs: ${metrics._counts.light}` : undefined} />
+                    <MetricCard compact title="Temperature" value={fmt(metrics.temp, 1)} unit="°C" icon={<span>🌡️</span>} subtitle={metrics?._counts?.temperature != null ? `Composite IDs: ${metrics._counts.temperature}` : undefined} />
+                    <MetricCard compact title="Humidity" value={fmt(metrics.humidity, 1)} unit="%" icon={<span>%</span>} subtitle={metrics?._counts?.humidity != null ? `Composite IDs: ${metrics._counts.humidity}` : undefined} />
+                </div>
             </div>
 
             {children ? <div className={cx("layer-children")}>{children}</div> : null}

--- a/src/pages/SystemAndLayerCards.module.css
+++ b/src/pages/SystemAndLayerCards.module.css
@@ -93,6 +93,22 @@
   gap:12px;
 }
 
+.metrics-group{
+  display:contents;
+}
+
+@media (max-width:600px){
+  .metrics-row{
+    display:flex;
+    flex-direction:column;
+  }
+  .metrics-group{
+    display:grid;
+    grid-template-columns:repeat(auto-fill,minmax(120px,1fr));
+    gap:12px;
+  }
+}
+
 .metric-bottom{ margin-top:8px; }
 
 .metric-title2{


### PR DESCRIPTION
## Summary
- Group water sensors and actuators separately from environment metrics
- Add responsive CSS so mobile shows water/actuators first, environment second

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a08979d8008328917382980a87824f