### PR TITLE
Remove system selection tabs from reports page

### DIFF
--- a/src/pages/ReportsPage.jsx
+++ b/src/pages/ReportsPage.jsx
@@ -3,7 +3,6 @@ import Header from '../components/Header';
 import { useLiveDevices } from '../components/dashboard/useLiveDevices';
 import { useHistory } from '../components/dashboard/useHistory';
 import styles from '../components/SensorDashboard.module.css';
-import SystemTabs from '../components/dashboard/SystemTabs';
 import ReportControls from '../components/dashboard/ReportControls';
 import ReportCharts from '../components/dashboard/ReportCharts';
 import { SENSOR_TOPIC, topics } from '../components/dashboard/dashboard.constants';
@@ -141,9 +140,6 @@ function ReportsPage() {
     return (
         <div className={styles.dashboard}>
             <Header title="Reports" />
-
-            {/* System selection tabs */}
-            <SystemTabs systems={Object.keys(deviceData)} activeSystem={activeSystem} onChange={setActiveSystem} />
 
             <div className={styles.section}>
                 <div className={styles.sectionBody}>


### PR DESCRIPTION
## Summary
- Remove system selection tabs from the Reports page
- Keep report controls and charts intact

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a63a2bd3d083288b0dbcbc678d096c