### PR TITLE
Enable all-systems filtering for reports

### DIFF
--- a/src/components/dashboard/useLiveDevices.js
+++ b/src/components/dashboard/useLiveDevices.js
@@ -60,29 +60,39 @@ export function useLiveDevices(topics, activeSystem) {
     useStomp(topics, handleStompMessage);
 
     const availableCompositeIds = useMemo(() => {
-        const sysData = deviceData[activeSystem] || {};
         const ids = new Set();
-        for (const topicDevices of Object.values(sysData)) {
-            for (const cid of Object.keys(topicDevices)) {
-                ids.add(cid);
+        const isAll = String(activeSystem).toLowerCase() === "all";
+        const systems = isAll ? Object.values(deviceData) : [deviceData[activeSystem] || {}];
+
+        for (const sysData of systems) {
+            for (const topicDevices of Object.values(sysData || {})) {
+                for (const cid of Object.keys(topicDevices)) {
+                    ids.add(cid);
+                }
             }
         }
+
         return Array.from(ids);
     }, [deviceData, activeSystem]);
 
     const mergedDevices = useMemo(() => {
-        const sysData = deviceData[activeSystem] || {};
         const combined = {};
-        for (const topicKey of Object.keys(sysData)) {
-            for (const [cid, data] of Object.entries(sysData[topicKey])) {
-                const existing = combined[cid] || {};
-                combined[cid] = {
-                    ...existing,
-                    ...data,
-                    controllers: mergeControllers(existing.controllers, data.controllers)
-                };
+        const isAll = String(activeSystem).toLowerCase() === "all";
+        const systems = isAll ? Object.values(deviceData) : [deviceData[activeSystem] || {}];
+
+        for (const sysData of systems) {
+            for (const topicKey of Object.keys(sysData || {})) {
+                for (const [cid, data] of Object.entries(sysData[topicKey])) {
+                    const existing = combined[cid] || {};
+                    combined[cid] = {
+                        ...existing,
+                        ...data,
+                        controllers: mergeControllers(existing.controllers, data.controllers)
+                    };
+                }
             }
         }
+
         return combined;
     }, [deviceData, activeSystem]);
 


### PR DESCRIPTION
## Summary
- Support selecting all systems in reports by aggregating live device IDs across every system
- Rebuild reports page filtering and metadata to handle an `ALL` active system

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a72d1458588328a8dc1102e3e58d25