### PR TITLE
Remove device filter from context and UI

### DIFF
--- a/src/components/SensorDashboard.jsx
+++ b/src/components/SensorDashboard.jsx
@@ -19,7 +19,6 @@ function SensorDashboard({ view, title = '' }) {
 
     // Filters from the sidebar
     const {
-        device: devFilter,
         layer: layerFilter,
         system: sysFilter,
         topic: topicFilter,
@@ -57,9 +56,8 @@ function SensorDashboard({ view, title = '' }) {
         );
     }, [deviceData]);
 
-    // 2) Populate sidebar lists (Device / Layer / System)
+    // 2) Populate sidebar lists (Layer / System)
     useEffect(() => {
-        const devices = Object.keys(deviceMeta);
         const layers = Array.from(
             new Set(Object.values(deviceMeta).map((m) => m.layer).filter(Boolean))
         );
@@ -69,7 +67,7 @@ function SensorDashboard({ view, title = '' }) {
                 Object.values(deviceData || {}).flatMap((sys) => Object.keys(sys || {}))
             )
         );
-        setLists({devices, layers, systems, topics: topicsList});
+        setLists({ layers, systems, topics: topicsList });
     }, [deviceMeta, deviceData, setLists]);
 
     // 3) Keep activeSystem in sync with the System filter
@@ -79,17 +77,16 @@ function SensorDashboard({ view, title = '' }) {
         }
     }, [sysFilter, activeSystem]);
 
-    // 4) Filter available device IDs based on all active filters
+    // 4) Filter available device IDs based on active filters
     const filteredCompositeIds = useMemo(() => {
         return availableCompositeIds.filter((compositeId) => {
             const meta = deviceMeta[compositeId] || {};
-            const okDev = devFilter === ALL || compositeId === devFilter;
             const okLay = layerFilter === ALL || meta.layer === layerFilter;
             const okSys = sysFilter === ALL || meta.system === sysFilter;
             const okTopic = topicFilter === ALL || (meta.topics || []).includes(topicFilter);
-            return okDev && okLay && okSys && okTopic;
+            return okLay && okSys && okTopic;
         });
-    }, [availableCompositeIds, deviceMeta, devFilter, layerFilter, sysFilter, topicFilter]);
+    }, [availableCompositeIds, deviceMeta, layerFilter, sysFilter, topicFilter]);
 
     // 5) Filter topics for live tables based on filtered devices
     const filteredSystemTopics = useMemo(() => {

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -5,7 +5,7 @@ import { useFilters, ALL } from "../context/FiltersContext";
 
 export default function Sidebar() {
     const [collapsed, setCollapsed] = useState(() => window.innerWidth < 768);
-    const { device, layer, system, topic, setDevice, setLayer, setSystem, setTopic, lists } = useFilters();
+    const { layer, system, topic, setLayer, setSystem, setTopic, lists } = useFilters();
 
     useEffect(() => {
         const handleResize = () => {
@@ -96,7 +96,6 @@ export default function Sidebar() {
                 {!collapsed && <div className={styles.filtersTitle}>Application filters</div>}
 
                 <CheckboxGroup title="Topic" list={lists.topics} value={topic} onChange={setTopic} />
-                <CheckboxGroup title="Composite ID" list={lists.devices} value={device} onChange={setDevice} />
                 <CheckboxGroup title="Layer" list={lists.layers} value={layer} onChange={setLayer} />
                 <CheckboxGroup title="System" list={lists.systems} value={system} onChange={setSystem} />
             </section>

--- a/src/context/FiltersContext.jsx
+++ b/src/context/FiltersContext.jsx
@@ -6,23 +6,27 @@ export const useFilters = () => useContext(Ctx);
 export const ALL = "ALL";
 
 export function FiltersProvider({ children, initialLists }) {
-    const [device, setDevice] = useState(ALL);
-    const [layer, setLayer]   = useState(ALL);
+    const [layer, setLayer] = useState(ALL);
     const [system, setSystem] = useState(ALL);
     const [topic, setTopic] = useState(ALL);
 
     const [lists, setLists] = useState({
-        devices: initialLists?.devices ?? [],
-        layers:  initialLists?.layers ?? [],
+        layers: initialLists?.layers ?? [],
         systems: initialLists?.systems ?? [],
-        topics:  initialLists?.topics ?? [],
+        topics: initialLists?.topics ?? [],
     });
 
     const value = useMemo(() => ({
-    ALL, device, layer, system, topic,
-    setDevice, setLayer, setSystem, setTopic,
-    lists, setLists,
-    }), [device, layer, system, topic, lists]);
+        ALL,
+        layer,
+        system,
+        topic,
+        setLayer,
+        setSystem,
+        setTopic,
+        lists,
+        setLists,
+    }), [layer, system, topic, lists]);
 
   return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
 }

--- a/src/pages/ReportsPage.jsx
+++ b/src/pages/ReportsPage.jsx
@@ -22,7 +22,6 @@ function ReportsPage() {
     const [refreshInterval, setRefreshInterval] = useState(60000);
 
     const {
-        device: devFilter,
         layer: layerFilter,
         system: sysFilter,
         topic: topicFilter,
@@ -66,11 +65,10 @@ function ReportsPage() {
 
     // Populate sidebar lists
     useEffect(() => {
-        const devices = Object.keys(deviceMeta);
         const layers = Array.from(new Set(Object.values(deviceMeta).map((m) => m.layer).filter(Boolean)));
         const systems = Object.keys(deviceData || {});
         const topicsList = Array.from(new Set(Object.values(deviceData || {}).flatMap((sys) => Object.keys(sys || {}))));
-        setLists({ devices, layers, systems, topics: topicsList });
+        setLists({ layers, systems, topics: topicsList });
     }, [deviceMeta, deviceData, setLists]);
 
     // Keep activeSystem in sync with filter
@@ -100,13 +98,12 @@ function ReportsPage() {
     const filteredCompositeIds = useMemo(() => {
         return availableCompositeIds.filter((id) => {
             const meta = deviceMeta[id] || {};
-            const okDev = devFilter === ALL || id === devFilter;
             const okLay = layerFilter === ALL || meta.layer === layerFilter;
             const okSys = activeSystem === ALL || meta.system === activeSystem;
             const okTopic = topicFilter === ALL || (meta.topics || []).includes(topicFilter);
-            return okDev && okLay && okSys && okTopic;
+            return okLay && okSys && okTopic;
         });
-    }, [availableCompositeIds, deviceMeta, devFilter, layerFilter, topicFilter, activeSystem]);
+    }, [availableCompositeIds, deviceMeta, layerFilter, topicFilter, activeSystem]);
 
     // Ensure selectedDevice is valid
     useEffect(() => {

--- a/tests/AppReportsRoute.test.jsx
+++ b/tests/AppReportsRoute.test.jsx
@@ -18,12 +18,11 @@ vi.stubEnv('BASE_URL', '/NFTMonitoring/');
 vi.mock('../src/context/FiltersContext', () => ({
   FiltersProvider: ({ children }) => <div>{children}</div>,
   useFilters: () => ({
-    device: 'ALL',
     layer: 'ALL',
     system: 'ALL',
     topic: 'ALL',
     setLists: () => {},
-    lists: { topics: [], devices: [], layers: [], systems: [] },
+    lists: { topics: [], layers: [], systems: [] },
   }),
   ALL: 'ALL',
 }));

--- a/tests/Reports.test.jsx
+++ b/tests/Reports.test.jsx
@@ -28,7 +28,6 @@ vi.mock('../src/components/dashboard/useHistory', () => ({
 
 vi.mock('../src/context/FiltersContext', () => ({
   useFilters: () => ({
-    device: 'ALL',
     layer: 'ALL',
     system: 'ALL',
     topic: 'ALL',


### PR DESCRIPTION
## Summary
- remove device filter from FiltersContext and lists
- drop Composite ID filter from sidebar
- adjust dashboard and reports pages for updated filters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a75891dc488328b571da710d4ad41f