### PR TITLE
feat: support multi-device report selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest run"
   },
   "dependencies": {
     "@stomp/stompjs": "^7.1.1",

--- a/src/components/dashboard/Live.jsx
+++ b/src/components/dashboard/Live.jsx
@@ -13,11 +13,22 @@ function Live({
     sensorData = {},
     mergedDevices = {},
 }) {
+    const isArray = Array.isArray(selectedDevice);
+    const selectedId = isArray ? selectedDevice[0] || "" : selectedDevice;
+    const handleChange = (e) => {
+        const val = e.target.value;
+        if (isArray) {
+            setSelectedDevice([val]);
+        } else {
+            setSelectedDevice(val);
+        }
+    };
+
     return (
         <div className={styles.section}>
             <div className={styles.sectionBody}>
                 {/* Live tables filtered by Device/Layer/System */}
-                <TopicSection systemTopics={filteredSystemTopics}/>
+                <TopicSection systemTopics={filteredSystemTopics} />
 
                 {/* Live spectrum chart for the selected device */}
                 {Object.keys(sensorTopicDevices).length > 0 && (
@@ -27,28 +38,34 @@ function Live({
                                 Composite ID:
                                 <select
                                     className={styles.intervalSelect}
-                                    value={selectedDevice}
-                                    onChange={(e) => setSelectedDevice(e.target.value)}
+                                    value={selectedId}
+                                    onChange={handleChange}
                                 >
                                     {filteredCompositeIds.map((id) => (
-                                        <option key={id} value={id}>{id}</option>
+                                        <option key={id} value={id}>
+                                            {id}
+                                        </option>
                                     ))}
                                 </select>
                             </label>
                         </div>
 
-                        <div className={styles.deviceLabel}>{selectedDevice}</div>
+                        {isArray && selectedDevice.length > 1 && (
+                            <div>Multiple devices selected; showing first.</div>
+                        )}
 
-                        {filteredCompositeIds.includes(selectedDevice) && (
+                        <div className={styles.deviceLabel}>{selectedId}</div>
+
+                        {filteredCompositeIds.includes(selectedId) && (
                             <div className={styles.spectrumBarChartWrapper}>
-                                <SpectrumBarChart sensorData={sensorData[selectedDevice]}/>
+                                <SpectrumBarChart sensorData={sensorData[selectedId]} />
                             </div>
                         )}
                     </>
                 )}
 
                 {/* Notes based on mergedDevices */}
-                <NotesBlock mergedDevices={mergedDevices}/>
+                <NotesBlock mergedDevices={mergedDevices} />
 
             </div>
         </div>

--- a/src/components/dashboard/ReportControls.jsx
+++ b/src/components/dashboard/ReportControls.jsx
@@ -8,9 +8,9 @@ function ReportControls({
   onToDateChange,
   onNow,
   onApply,
-  selectedDevice,
+  selectedDevices = [],
   availableCompositeIds = [],
-  onDeviceChange,
+  onDevicesChange,
   autoRefresh,
   onAutoRefreshChange,
   refreshInterval,
@@ -41,7 +41,16 @@ function ReportControls({
       <div className={styles.filterRow}>
         <label className={styles.filterLabel}>
           Composite ID:
-          <select className={styles.intervalSelect} value={selectedDevice} onChange={onDeviceChange}>
+          <select
+            className={styles.intervalSelect}
+            multiple
+            value={selectedDevices}
+            onChange={(e) =>
+              onDevicesChange(
+                Array.from(e.target.selectedOptions).map((opt) => opt.value)
+              )
+            }
+          >
             {availableCompositeIds.map((id) => (
               <option key={id} value={id}>
                 {id}

--- a/src/pages/ReportsPage.jsx
+++ b/src/pages/ReportsPage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Header from '../components/Header';
 import { useLiveDevices } from '../components/dashboard/useLiveDevices';
 import { useHistory } from '../components/dashboard/useHistory';
@@ -12,7 +12,7 @@ import { useFilters, ALL } from '../context/FiltersContext';
 function ReportsPage() {
     const [activeSystem, setActiveSystem] = useState(ALL);
     const { deviceData, availableCompositeIds } = useLiveDevices(topics, activeSystem);
-    const [selectedDevice, setSelectedDevice] = useState('');
+    const [selectedDevices, setSelectedDevices] = useState([]);
 
     const now = Date.now();
     const [fromDate, setFromDate] = useState(toLocalInputValue(new Date(now - 6 * 60 * 60 * 1000)));
@@ -105,46 +105,98 @@ function ReportsPage() {
         });
     }, [availableCompositeIds, deviceMeta, layerFilter, topicFilter, activeSystem]);
 
-    // Ensure selectedDevice is valid
+    // Ensure selectedDevices are valid
     useEffect(() => {
-        if (filteredCompositeIds.length && !filteredCompositeIds.includes(selectedDevice)) {
-            setSelectedDevice(filteredCompositeIds[0]);
+        if (!filteredCompositeIds.length) {
+            setSelectedDevices([]);
+            return;
         }
-    }, [filteredCompositeIds, selectedDevice]);
+        setSelectedDevices((prev) => {
+            const valid = prev.filter((id) => filteredCompositeIds.includes(id));
+            return valid.length ? valid : [filteredCompositeIds[0]];
+        });
+    }, [filteredCompositeIds]);
 
-    const {
-        rangeData = [],
-        tempRangeData = [],
-        phRangeData = [],
-        ecTdsRangeData = [],
-        doRangeData = [],
-        xDomain = [],
-        startTime = 0,
-        endTime = 0,
-        fetchReportData = () => {},
-    } = useHistory(selectedDevice, fromDate, toDate, autoRefresh, refreshInterval);
+    const fetchersRef = useRef({});
+    const registerFetcher = useCallback((id, fn) => {
+        fetchersRef.current[id] = fn;
+    }, []);
 
-    // Determine which report sections to display
-    const sensorTypesForSelected = useMemo(() => {
-        const match = sensorTopicDevices[selectedDevice];
-        const sensors = match?.sensors || [];
-        return sensors.map((s) => (s.sensorType || s.valueType || '').toLowerCase());
-    }, [sensorTopicDevices, selectedDevice]);
+    const handleApply = () => {
+        selectedDevices.forEach((id) => fetchersRef.current[id]?.());
+    };
 
-    const sensorNamesForSelected = useMemo(() => {
-        const match = sensorTopicDevices[selectedDevice];
-        const sensors = match?.sensors || [];
-        return sensors.map((s) => (s.sensorName || s.source || '-').toLowerCase());
-    }, [sensorTopicDevices, selectedDevice]);
+    const DeviceReport = ({ deviceId }) => {
+        const {
+            rangeData = [],
+            tempRangeData = [],
+            phRangeData = [],
+            ecTdsRangeData = [],
+            doRangeData = [],
+            xDomain = [],
+            fetchReportData = () => {},
+        } = useHistory(deviceId, fromDate, toDate, autoRefresh, refreshInterval);
 
-    const showTempHum = sensorNamesForSelected.includes('sht3x');
-    const hasAs734x = sensorNamesForSelected.includes('as7343') || sensorNamesForSelected.includes('as7341');
-    const showSpectrum = hasAs734x;
-    const showClearLux = sensorNamesForSelected.includes('veml7700') || hasAs734x;
-    const showPh = sensorTypesForSelected.includes('ph');
-    const showEcTds = sensorTypesForSelected.includes('ec') || sensorTypesForSelected.includes('tds');
-    const showDo = sensorTypesForSelected.includes('do') || sensorTypesForSelected.includes('dissolvedoxygen');
-    const showAnyReport = showTempHum || showSpectrum || showClearLux || showPh || showEcTds || showDo;
+        useEffect(() => {
+            registerFetcher(deviceId, fetchReportData);
+        }, [deviceId, fetchReportData, registerFetcher]);
+
+        const sensorTypesForSelected = useMemo(() => {
+            const match = sensorTopicDevices[deviceId];
+            const sensors = match?.sensors || [];
+            return sensors.map((s) => (s.sensorType || s.valueType || '').toLowerCase());
+        }, [sensorTopicDevices, deviceId]);
+
+        const sensorNamesForSelected = useMemo(() => {
+            const match = sensorTopicDevices[deviceId];
+            const sensors = match?.sensors || [];
+            return sensors.map((s) => (s.sensorName || s.source || '-').toLowerCase());
+        }, [sensorTopicDevices, deviceId]);
+
+        const showTempHum = sensorNamesForSelected.includes('sht3x');
+        const hasAs734x =
+            sensorNamesForSelected.includes('as7343') ||
+            sensorNamesForSelected.includes('as7341');
+        const showSpectrum = hasAs734x;
+        const showClearLux =
+            sensorNamesForSelected.includes('veml7700') || hasAs734x;
+        const showPh = sensorTypesForSelected.includes('ph');
+        const showEcTds =
+            sensorTypesForSelected.includes('ec') ||
+            sensorTypesForSelected.includes('tds');
+        const showDo =
+            sensorTypesForSelected.includes('do') ||
+            sensorTypesForSelected.includes('dissolvedoxygen');
+        const showAnyReport =
+            showTempHum ||
+            showSpectrum ||
+            showClearLux ||
+            showPh ||
+            showEcTds ||
+            showDo;
+
+        if (!showAnyReport) {
+            return <div>No reports available for this composite ID.</div>;
+        }
+
+        return (
+            <ReportCharts
+                showTempHum={showTempHum}
+                showSpectrum={showSpectrum}
+                showClearLux={showClearLux}
+                showPh={showPh}
+                showEcTds={showEcTds}
+                showDo={showDo}
+                rangeData={rangeData}
+                tempRangeData={tempRangeData}
+                phRangeData={phRangeData}
+                ecTdsRangeData={ecTdsRangeData}
+                doRangeData={doRangeData}
+                xDomain={xDomain}
+                selectedDevice={deviceId}
+            />
+        );
+    };
 
     return (
         <div className={styles.dashboard}>
@@ -152,44 +204,32 @@ function ReportsPage() {
 
             <div className={styles.section}>
                 <div className={styles.sectionBody}>
-                    {!showAnyReport ? (
-                        <div>No reports available for this composite ID.</div>
-                    ) : (
-                        <>
-                            <ReportControls
-                                fromDate={fromDate}
-                                toDate={toDate}
-                                onFromDateChange={(e) => setFromDate(e.target.value)}
-                                onToDateChange={(e) => setToDate(e.target.value)}
-                                onNow={() => setToDate(toLocalInputValue(new Date()))}
-                                onApply={fetchReportData}
-                                selectedDevice={selectedDevice}
-                                availableCompositeIds={filteredCompositeIds}
-                                onDeviceChange={(e) => setSelectedDevice(e.target.value)}
-                                autoRefresh={autoRefresh}
-                                onAutoRefreshChange={(e) => setAutoRefresh(e.target.checked)}
-                                refreshInterval={refreshInterval}
-                                onRefreshIntervalChange={(e) => setRefreshInterval(Number(e.target.value))}
-                                rangeLabel={`From: ${formatTime(startTime)} until: ${formatTime(endTime)}`}
-                            />
+                    <>
+                        <ReportControls
+                            fromDate={fromDate}
+                            toDate={toDate}
+                            onFromDateChange={(e) => setFromDate(e.target.value)}
+                            onToDateChange={(e) => setToDate(e.target.value)}
+                            onNow={() => setToDate(toLocalInputValue(new Date()))}
+                            onApply={handleApply}
+                            selectedDevices={selectedDevices}
+                            availableCompositeIds={filteredCompositeIds}
+                            onDevicesChange={(vals) => setSelectedDevices(vals)}
+                            autoRefresh={autoRefresh}
+                            onAutoRefreshChange={(e) => setAutoRefresh(e.target.checked)}
+                            refreshInterval={refreshInterval}
+                            onRefreshIntervalChange={(e) =>
+                                setRefreshInterval(Number(e.target.value))
+                            }
+                            rangeLabel={`From: ${formatTime(
+                                Date.parse(fromDate)
+                            )} until: ${formatTime(Date.parse(toDate))}`}
+                        />
 
-                            <ReportCharts
-                                showTempHum={showTempHum}
-                                showSpectrum={showSpectrum}
-                                showClearLux={showClearLux}
-                                showPh={showPh}
-                                showEcTds={showEcTds}
-                                showDo={showDo}
-                                rangeData={rangeData}
-                                tempRangeData={tempRangeData}
-                                phRangeData={phRangeData}
-                                ecTdsRangeData={ecTdsRangeData}
-                                doRangeData={doRangeData}
-                                xDomain={xDomain}
-                                selectedDevice={selectedDevice}
-                            />
-                        </>
-                    )}
+                        {selectedDevices.map((id) => (
+                            <DeviceReport key={id} deviceId={id} />
+                        ))}
+                    </>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- allow choosing multiple composite IDs in report controls
- display charts for each selected device
- guard Live view against multi-selection, showing the first device when several are chosen
- run vitest in single-run mode and clarify handler naming

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a76267b19483288541536717e9cc76