### PR TITLE
Add compare panel and CSV export to reports

### DIFF
--- a/src/components/reports/ComparePanel.jsx
+++ b/src/components/reports/ComparePanel.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+function ComparePanel({ items = [], onClear }) {
+  return (
+    <div style={{ border: '1px solid #ddd', padding: '10px', marginTop: '20px' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '10px' }}>
+        <div>Compare ({items.length})</div>
+        {items.length > 0 && (
+          <button type="button" onClick={onClear}>Clear All</button>
+        )}
+      </div>
+      <div style={{ maxHeight: '150px', overflowY: 'auto' }}>
+        {items.length === 0 ? (
+          <div>No filters selected.</div>
+        ) : (
+          <ul style={{ paddingLeft: '20px', margin: 0 }}>
+            {items.map((f, idx) => (
+              <li key={idx}>
+                Timing: {f.timing?.join(', ') || 'None'}; Location: {f.location?.join(', ') || 'None'}; Sensor: {f.sensorType?.join(', ') || 'None'}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default ComparePanel;
+

--- a/src/components/reports/ReportsUX.jsx
+++ b/src/components/reports/ReportsUX.jsx
@@ -5,7 +5,7 @@ import SensorTypeFilters from './SensorTypeFilters';
 import { useFilters } from '../../context/FiltersContext';
 import styles from './ReportsUX.module.css';
 
-function ReportsUX({ onRun, onExport }) {
+function ReportsUX({ onRun, onExport, onAddToCompare }) {
   const { timing, location, sensorType } = useFilters();
   const filters = { timing, location, sensorType };
 
@@ -27,9 +27,16 @@ function ReportsUX({ onRun, onExport }) {
         <button
           type="button"
           className={styles.exportButton}
+          onClick={() => onAddToCompare?.(filters)}
+        >
+          Add to Compare
+        </button>
+        <button
+          type="button"
+          className={styles.exportButton}
           onClick={() => onExport?.(filters)}
         >
-          Export
+          Export CSV
         </button>
       </div>
     </div>

--- a/src/pages/ReportsPage.jsx
+++ b/src/pages/ReportsPage.jsx
@@ -1,25 +1,53 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import Header from '../components/Header';
 import ReportsUX from '../components/reports/ReportsUX';
+import ComparePanel from '../components/reports/ComparePanel';
 import styles from '../components/SensorDashboard.module.css';
 
 function ReportsPage() {
+  const [compareList, setCompareList] = useState([]);
+
   const handleRun = (filters) => {
     // Placeholder for data fetching logic
     console.log('Run report', filters);
   };
 
-  const handleExport = (filters) => {
-    console.log('Export report', filters);
+  const addToCompare = (filters) => {
+    setCompareList((prev) => [...prev, filters]);
   };
+
+  const handleExport = () => {
+    if (typeof document === 'undefined') return;
+    const rows = Array.from(document.querySelectorAll('table tr'));
+    if (!rows.length) return;
+    const csv = rows
+      .map((row) =>
+        Array.from(row.querySelectorAll('th,td'))
+          .map((cell) => `"${cell.textContent.replace(/"/g, '""')}"`)
+          .join(',')
+      )
+      .join('\n');
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'report.csv';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
+  const clearCompare = () => setCompareList([]);
 
   return (
     <div className={styles.dashboard}>
       <Header title="Reports" />
       <div className={styles.section}>
         <div className={styles.sectionBody}>
-          <ReportsUX onRun={handleRun} onExport={handleExport} />
+          <ReportsUX onRun={handleRun} onExport={handleExport} onAddToCompare={addToCompare} />
+          <ComparePanel items={compareList} onClear={clearCompare} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add ComparePanel component for listing selected filter configurations and clearing them
- enhance ReportsUX with Add to Compare and Export CSV actions
- update ReportsPage to manage compare selections and export table data as CSV download

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a76cc2c9908328bb0e3c4107e0a7e4