### PR TITLE
Add report tabs with chart, table, and raw views

### DIFF
--- a/src/components/reports/ChartsPanel.jsx
+++ b/src/components/reports/ChartsPanel.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+
+function ChartsPanel({ data = [] }) {
+  return (
+    <div style={{ width: '100%', height: 300 }}>
+      <ResponsiveContainer>
+        <LineChart data={data}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="time" />
+          <YAxis />
+          <Tooltip />
+          <Line type="monotone" dataKey="value" stroke="#8884d8" />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+export default ChartsPanel;

--- a/src/components/reports/RawPanel.jsx
+++ b/src/components/reports/RawPanel.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function RawPanel({ data = [] }) {
+  return (
+    <pre style={{ overflowX: 'auto' }}>
+      {JSON.stringify(data, null, 2)}
+    </pre>
+  );
+}
+
+export default RawPanel;

--- a/src/components/reports/TablePanel.jsx
+++ b/src/components/reports/TablePanel.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+function TablePanel({ data = [] }) {
+  if (!Array.isArray(data) || data.length === 0) {
+    return <div>No data available.</div>;
+  }
+
+  const headers = Object.keys(data[0] || {});
+
+  return (
+    <table>
+      <thead>
+        <tr>
+          {headers.map((h) => (
+            <th key={h}>{h}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((row, idx) => (
+          <tr key={idx}>
+            {headers.map((h) => (
+              <td key={h}>{String(row[h])}</td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+export default TablePanel;

--- a/src/components/reports/Tabs.jsx
+++ b/src/components/reports/Tabs.jsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import ChartsPanel from './ChartsPanel';
+import TablePanel from './TablePanel';
+import RawPanel from './RawPanel';
+import styles from '../SensorDashboard.module.css';
+
+function Tabs({ data = [] }) {
+  const [active, setActive] = useState('charts');
+
+  let content = null;
+  if (active === 'table') content = <TablePanel data={data} />;
+  else if (active === 'raw') content = <RawPanel data={data} />;
+  else content = <ChartsPanel data={data} />;
+
+  return (
+    <div>
+      <div className={styles.tabBar}>
+        <button
+          type="button"
+          className={`${styles.tab} ${active === 'charts' ? styles.activeTab : ''}`}
+          onClick={() => setActive('charts')}
+        >
+          Charts
+        </button>
+        <button
+          type="button"
+          className={`${styles.tab} ${active === 'table' ? styles.activeTab : ''}`}
+          onClick={() => setActive('table')}
+        >
+          Table
+        </button>
+        <button
+          type="button"
+          className={`${styles.tab} ${active === 'raw' ? styles.activeTab : ''}`}
+          onClick={() => setActive('raw')}
+        >
+          Raw
+        </button>
+      </div>
+      {content}
+    </div>
+  );
+}
+
+export default Tabs;

--- a/src/pages/ReportsPage.jsx
+++ b/src/pages/ReportsPage.jsx
@@ -3,14 +3,20 @@ import React, { useState } from 'react';
 import Header from '../components/Header';
 import ReportsUX from '../components/reports/ReportsUX';
 import ComparePanel from '../components/reports/ComparePanel';
+import Tabs from '../components/reports/Tabs';
 import styles from '../components/SensorDashboard.module.css';
 
 function ReportsPage() {
   const [compareList, setCompareList] = useState([]);
+  const [reportData, setReportData] = useState([]);
 
   const handleRun = (filters) => {
     // Placeholder for data fetching logic
     console.log('Run report', filters);
+    setReportData([
+      { time: '2024-01-01', value: 10 },
+      { time: '2024-01-02', value: 15 },
+    ]);
   };
 
   const addToCompare = (filters) => {
@@ -48,6 +54,7 @@ function ReportsPage() {
         <div className={styles.sectionBody}>
           <ReportsUX onRun={handleRun} onExport={handleExport} onAddToCompare={addToCompare} />
           <ComparePanel items={compareList} onClear={clearCompare} />
+          <Tabs data={reportData} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Add Tabs component to switch between chart, table, and raw JSON panels
- Render line chart with Recharts in ChartsPanel
- Show tabbed data on Reports page with sample dataset

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a78113d06483289dfd4f3f6b307fe6