### PR TITLE
fix: handle missing report data in ReportsPage

### DIFF
--- a/src/pages/ReportsPage.jsx
+++ b/src/pages/ReportsPage.jsx
@@ -12,11 +12,14 @@ function ReportsPage() {
   const [refreshInterval, setRefreshInterval] = useState(60000);
   const [bucket, setBucket] = useState('1m');
   const [activeFilters, setActiveFilters] = useState(null);
+  const [reportData, setReportData] = useState([]);
   const intervalRef = useRef(null);
 
   const handleRun = useCallback((filters) => {
     const merged = { ...filters, bucket };
     setActiveFilters(merged);
+    // Placeholder for report generation logic
+    setReportData([]);
     console.log('Run report', merged);
   }, [bucket]);
 


### PR DESCRIPTION
## Summary
- prevent `ReportsPage` from referencing undefined `reportData`
- set up placeholder state for report data when running reports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a784fe2e448328967c2bf8f4c126ea