### PR TITLE
refactor: guard live_now logging with env flag

### DIFF
--- a/src/hooks/useLiveNow.js
+++ b/src/hooks/useLiveNow.js
@@ -16,7 +16,9 @@ export function useLiveNow() {
     };
 
     const handle = useCallback((_topic, data) => {
-        console.log('[live_now] message:', data);
+        if (import.meta.env.VITE_DEBUG) {
+            console.log('[live_now] message:', data);
+        }
         setStatus(normalize(data));
     }, []);
 


### PR DESCRIPTION
## Summary
- conditionally log live_now messages when `VITE_DEBUG` flag is set

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7861a147c832894c1c4236953159a