### PR TITLE
Display device names in Reports filters

### DIFF
--- a/src/pages/Reports/components/ReportFiltersCompare.jsx
+++ b/src/pages/Reports/components/ReportFiltersCompare.jsx
@@ -105,17 +105,20 @@ export default function ReportFiltersCompare({
         }
     }, []);
 
-    const systems = systemsProp.length ? systemsProp : useMemo(() => {
+    const memoSystems = useMemo(() => {
         return Array.from(new Set((catalog?.systems || []).map(s => s.id))).sort();
     }, [catalog]);
+    const systems = systemsProp.length ? systemsProp : memoSystems;
 
-    const layers = layersProp.length ? layersProp : useMemo(() => {
+    const memoLayers = useMemo(() => {
         return Array.from(new Set((catalog?.devices || []).map(d => d.layerId))).sort();
     }, [catalog]);
+    const layers = layersProp.length ? layersProp : memoLayers;
 
-    const devices = devicesProp.length ? devicesProp : useMemo(() => {
+    const memoDevices = useMemo(() => {
         return Array.from(new Set((catalog?.devices || []).map(d => d.deviceId))).sort();
     }, [catalog]);
+    const devices = devicesProp.length ? devicesProp : memoDevices;
 
     const sensorGroups = useMemo(() => {
         const groups = {water: [], light: [], blue: [], red: [], airq: []};
@@ -214,12 +217,16 @@ export default function ReportFiltersCompare({
                         }} onNone={() => {
                         }}/>
                         <div className={styles.checklist}>
-                            {devices.map(d => (
-                                <label key={d} className={styles.item}>
-                                    <input type="checkbox" checked={selectedDevice === d}
-                                           onChange={() => onDeviceChange && onDeviceChange({target: {value: d}})}/> {d}
-                                </label>
-                            ))}
+                            {devices.map(d => {
+                                const value = typeof d === 'string' ? d : d.value;
+                                const label = typeof d === 'string' ? d : (d.label || d.value);
+                                return (
+                                    <label key={value} className={styles.item}>
+                                        <input type="checkbox" checked={selectedDevice === value}
+                                               onChange={() => onDeviceChange && onDeviceChange({target: {value}})}/> {label}
+                                    </label>
+                                );
+                            })}
                         </div>
                     </div>
                 </div>

--- a/src/pages/Reports/index.jsx
+++ b/src/pages/Reports/index.jsx
@@ -182,11 +182,11 @@ function Reports() {
                                // location lists from computed metadata
                                systems={Object.keys(deviceData || {})}
                                layers={Array.from(new Set(Object.values(deviceMeta).map(m => m.layer).filter(Boolean)))}
-                               devices={filteredCompositeIds}
+                               devices={filteredCompositeIds.map(id => ({ value: id, label: deviceMeta[id]?.baseId || id }))}
                                selectedSystem={activeSystem}
                                onSystemChange={(e) => setActiveSystem(e.target.value)}
                                selectedLayer={layerFilter !== ALL ? layerFilter : (deviceMeta[selectedDevice]?.layer || '')}
-                               onLayerChange={(e) => {/* optional: wire to FiltersContext if لازم */}}
+                               onLayerChange={() => {/* optional: wire to FiltersContext if لازم */}}
                                selectedDevice={selectedDevice}
                                onDeviceChange={(e) => setSelectedDevice(e.target.value)}
                                // sensors (detected)

--- a/tests/Reports.test.jsx
+++ b/tests/Reports.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 
 const liveDevicesMock = vi.fn();
@@ -99,5 +100,28 @@ test('Reports page defaults to first available system when initial system has no
   render(<Reports />);
   await waitFor(() => expect(ReportCharts).toHaveBeenCalled());
   expect(screen.queryByText('No reports available for this composite ID.')).toBeNull();
+});
+
+test('Devices box displays device name instead of composite ID', () => {
+  liveDevicesMock.mockReturnValue({
+    deviceData: {
+      S01: {
+        growSensors: {
+          L01G01: {
+            deviceId: 'G01',
+            layer: 'L01',
+            sensors: [{ sensorName: 'SHT3x' }],
+          },
+        },
+      },
+    },
+    sensorData: {},
+    availableCompositeIds: ['L01G01'],
+    mergedDevices: {},
+  });
+
+  render(<Reports />);
+  expect(screen.getByText('G01')).toBeInTheDocument();
+  expect(screen.queryByText('L01G01')).toBeNull();
 });
 


### PR DESCRIPTION
## Summary
- Show base device names in Reports device filter instead of composite IDs
- Refactor ReportFiltersCompare to support value/label pairs for devices
- Add test verifying device names are rendered

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8b7b06294832887cfcc83df61aef7