### PR TITLE
feat: add reusable history chart component

### DIFF
--- a/src/components/HistoryChart.jsx
+++ b/src/components/HistoryChart.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import {
+    LineChart,
+    Line,
+    XAxis,
+    YAxis,
+    CartesianGrid,
+    Tooltip,
+    Label,
+    ResponsiveContainer,
+} from 'recharts';
+import palette from '../colorPalette';
+
+const HistoryChart = ({
+    data,
+    xDataKey,
+    yDataKey,
+    yLabel,
+    title,
+    width = 600,
+    height = 300,
+}) => (
+    <ResponsiveContainer width="100%" height={height} debounce={200}>
+        <LineChart
+            width={width}
+            height={height}
+            data={data}
+            margin={{ top: 20, right: 30, left: 0, bottom: 50 }}
+            isAnimationActive={false}
+        >
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis
+                dataKey={xDataKey}
+                type="number"
+                domain={['auto', 'auto']}
+                scale="time"
+                tick={{ fontSize: 10 }}
+                tickFormatter={(val) => {
+                    const d = new Date(val);
+                    return `${d.getMonth() + 1}/${d.getDate()}`;
+                }}
+            />
+            <YAxis>
+                {yLabel && (
+                    <Label value={yLabel} angle={-90} position="insideLeft" style={{ textAnchor: 'middle' }} />
+                )}
+            </YAxis>
+            <Tooltip />
+            <Line
+                type="monotone"
+                dataKey={yDataKey}
+                stroke={palette[4]}
+                dot={false}
+                isAnimationActive={false}
+            />
+            {title && (
+                <text x={width / 2} y={0} textAnchor="middle" dominantBaseline="hanging">
+                    {title}
+                </text>
+            )}
+        </LineChart>
+    </ResponsiveContainer>
+);
+
+export default React.memo(HistoryChart);
+

--- a/tests/HistoryChart.test.jsx
+++ b/tests/HistoryChart.test.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import HistoryChart from '../src/components/HistoryChart';
+
+beforeAll(() => {
+    Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+        configurable: true,
+        value: 600,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+        configurable: true,
+        value: 300,
+    });
+});
+
+describe('HistoryChart', () => {
+    const mockData = [
+        { time: Date.now() - 3600 * 1000, value: 1 },
+        { time: Date.now(), value: 2 },
+    ];
+
+    it('renders without crashing', () => {
+        render(
+            <HistoryChart
+                data={mockData}
+                xDataKey="time"
+                yDataKey="value"
+                yLabel="Value"
+                title="Test Chart"
+            />,
+        );
+    });
+
+    it('renders a recharts container', () => {
+        const { container } = render(
+            <HistoryChart data={mockData} xDataKey="time" yDataKey="value" yLabel="Value" />,
+        );
+        const rechartsWrapper = container.querySelector('.recharts-responsive-container');
+        expect(rechartsWrapper).toBeTruthy();
+    });
+});
+


### PR DESCRIPTION
## Summary
- add generic `HistoryChart` component for rendering line charts
- test the component renders correctly

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8b957366483288de35ba3f8f5587a