### PR TITLE
Fix sensor type filter fallback when catalog missing

### DIFF
--- a/src/pages/Reports/components/ReportFiltersCompare.jsx
+++ b/src/pages/Reports/components/ReportFiltersCompare.jsx
@@ -65,6 +65,9 @@ export default function ReportFiltersCompare({
                                                  onLayerChange,
                                                  selectedDevice = '',
                                                  onDeviceChange,
+                                                 // sensors detected for selected device
+                                                 sensorNames = [],
+                                                 sensorTypes = [],
                                                  // sensor groups
                                                  water: waterProp,
                                                  light: lightProp,
@@ -126,7 +129,12 @@ export default function ReportFiltersCompare({
 
     const sensorGroups = useMemo(() => {
         const groups = {water: [], light: [], blue: [], red: [], airq: []};
-        const sensors = (catalog?.devices || []).flatMap(d => d.sensors || []);
+        let sensors = (catalog?.devices || []).flatMap(d => d.sensors || []);
+        // Fallback to provided sensor lists when catalog data is unavailable
+        if (!sensors.length) {
+            const fallback = Array.from(new Set([...(sensorNames || []), ...(sensorTypes || [])])).filter(Boolean);
+            sensors = fallback.map((n) => ({sensorName: n}));
+        }
         sensors.forEach(s => {
             const rawName = s?.sensorName || s?.sensorType || s?.valueType || '';
             const name = rawName.toString();
@@ -141,7 +149,7 @@ export default function ReportFiltersCompare({
             if (['temp', 'humidity', 'co2', 'voc', 'air'].some(k => lower.includes(k))) add('airq');
         });
         return groups;
-    }, [catalog]);
+    }, [catalog, sensorNames, sensorTypes]);
 
     const water = waterProp || {options: sensorGroups.water, values: []};
     const light = lightProp || {options: sensorGroups.light, values: []};

--- a/tests/ReportFiltersCompareFilter.test.jsx
+++ b/tests/ReportFiltersCompareFilter.test.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ReportFiltersCompare from '../src/pages/Reports/components/ReportFiltersCompare.jsx';
+
+test('displays sensor types from provided lists when catalog is absent', () => {
+  render(
+    <ReportFiltersCompare
+      fromDate=""
+      toDate=""
+      onFromDateChange={() => {}}
+      onToDateChange={() => {}}
+      systems={[]}
+      layers={[]}
+      devices={[]}
+      sensorNames={['SHT3x']}
+      sensorTypes={['pH', 'temperature']}
+      rangeLabel=""
+    />
+  );
+  expect(screen.getByText('pH')).toBeInTheDocument();
+  expect(screen.getByText('temperature')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- Populate sensor groups in report filter from detected sensor names/types when no catalog is available
- Add regression test for report filter sensor type options

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a8bbf1594c8328814c66b08f138e1f