### PR TITLE
Keep sidebar and header fixed during scrolling

### DIFF
--- a/src/layouts/MainLayout.jsx
+++ b/src/layouts/MainLayout.jsx
@@ -6,9 +6,9 @@ import { FiltersProvider } from "../context/FiltersContext";
 export default function MainLayout() {
     return (
     <FiltersProvider>
-      <div style={{ display: "flex" }}>
+      <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
             <Sidebar />
-            <main style={{ flexGrow: 1 }}>
+            <main style={{ flexGrow: 1, overflowY: "auto" }}>
                 <Outlet />
             </main>
         </div>

--- a/src/pages/common/Header/Header.module.css
+++ b/src/pages/common/Header/Header.module.css
@@ -4,6 +4,9 @@
     padding: 10px 20px;
     margin-bottom: 20px;
     text-align: center;
+    position: sticky;
+    top: 0;
+    z-index: 1;
 }
 
 .title {

--- a/src/pages/common/Sidebar/Sidebar.module.css
+++ b/src/pages/common/Sidebar/Sidebar.module.css
@@ -1,4 +1,4 @@
-.sidebar { height: 100%; min-height: 100vh; width: 240px; background:#0f1a2b; color:#e8edf6; display:flex; flex-direction:column; transition:width .25s; box-shadow: inset -1px 0 0 #1c2a40; }
+.sidebar { height:100vh; width:240px; background:#0f1a2b; color:#e8edf6; display:flex; flex-direction:column; transition:width .25s; box-shadow: inset -1px 0 0 #1c2a40; position:sticky; top:0; }
 .collapsed { width: 72px; }
 
 /* header */


### PR DESCRIPTION
## Summary
- prevent page scrolling by constraining layout to viewport height and scrolling only main content
- make sidebar and header sticky so they remain visible while content scrolls

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aaf5b6945c8328b282fe8e27905021