### PR TITLE
Fix report chart device title spacing

### DIFF
--- a/src/pages/Reports/components/ReportCharts.jsx
+++ b/src/pages/Reports/components/ReportCharts.jsx
@@ -11,7 +11,7 @@ const toSeries = (byCid, yKey) =>
     }));
 
 const withDevice = (title, selectedDevice) =>
-    selectedDevice ? `${title}(${selectedDevice})` : title;
+    selectedDevice ? `${title} (${selectedDevice})` : title;
 
 
 export default function ReportCharts({

--- a/src/pages/Reports/components/ReportFiltersCompare.jsx
+++ b/src/pages/Reports/components/ReportFiltersCompare.jsx
@@ -87,7 +87,9 @@ export default function ReportFiltersCompare(props) {
             const b = localStorage.getItem('deviceCatalog');
             const raw = a || b;
             if (raw) setCatalog(JSON.parse(raw));
-        } catch {}
+        } catch {
+            /* ignore parse errors */
+        }
     }, []);
 
     // composite IDs

--- a/src/pages/Reports/index.jsx
+++ b/src/pages/Reports/index.jsx
@@ -30,7 +30,10 @@ function useDevicesMeta() {
     const [meta, setMeta] = useState({devices: []});
     useEffect(() => {
         const cached = localStorage.getItem("reportsMeta:v1") || localStorage.getItem("deviceCatalog");
-        if (cached) { try { setMeta(JSON.parse(cached)); } catch {} }
+        if (cached) {
+            try { setMeta(JSON.parse(cached)); }
+            catch { /* ignore parse errors */ }
+        }
     }, []);
     return meta;
 }

--- a/tests/ReportChartsDeviceTitle.test.jsx
+++ b/tests/ReportChartsDeviceTitle.test.jsx
@@ -24,6 +24,6 @@ function setup() {
 
 test('adds selected device to chart titles', () => {
   setup();
-  expect(screen.getByText('Temperature(L01G03)')).toBeInTheDocument();
-  expect(screen.queryByText('Humidity(L01G03)')).not.toBeInTheDocument();
+  expect(screen.getByText('Temperature (L01G03)')).toBeInTheDocument();
+  expect(screen.queryByText('Humidity (L01G03)')).not.toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- show selected device names in report chart titles with clearer spacing
- document ignored parsing errors when reading cached report metadata

## Testing
- `npx vitest run`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ab76e8cbc48328a122f4f793e0702a