### PR TITLE
feat: allow series color overrides

### DIFF
--- a/src/components/HistoryChart.jsx
+++ b/src/components/HistoryChart.jsx
@@ -7,7 +7,7 @@ import palette from "../colorPalette";
 /**
  * Props:
  * - xDataKey: string (e.g., 'time')
- * - series: Array<{ name: string, data: any[], yDataKey: string }>
+ * - series: Array<{ name: string; data: any[]; yDataKey: string; color?: string }>
  * - yLabel: string
  * - title?: string
  * - height?: number
@@ -50,7 +50,7 @@ const HistoryChart = ({
                     type="monotone"
                     dataKey={s.yDataKey}
                     name={s.name}
-                    stroke={palette[i % palette.length]}
+                    stroke={s.color || palette[i % palette.length]}
                     dot={false}
                     isAnimationActive={false}
                     connectNulls


### PR DESCRIPTION
## Summary
- document `color` override support for `HistoryChart` series prop
- allow `HistoryChart` lines to use provided color before fallback palette

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: 6 errors, 11 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b03eb2da0c8328ac05026583d77279