### PR TITLE
feat: colorize report chart spectrum

### DIFF
--- a/src/pages/Reports/components/ReportCharts.jsx
+++ b/src/pages/Reports/components/ReportCharts.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import HistoryChart from "../../../components/HistoryChart";
+import spectralColors from "../../../spectralColors";
 import styles from "../../common/SensorDashboard.module.css";
 
 // English comments: helper to convert {cid: data[]} to multi-series spec
@@ -13,7 +14,7 @@ const toSeries = (byCid, yKey) =>
 // English comments: build series for multiple spectrum keys across CIDs
 const toSpectrumSeries = (byCid, keys = []) =>
     Object.entries(byCid || {}).flatMap(([cid, data]) =>
-        keys.map((k) => ({ name: `${cid} ${k}`, data, yDataKey: k }))
+        keys.map((k) => ({ name: `${cid} ${k}`, data, yDataKey: k, color: spectralColors[k] || undefined }))
     );
 
 const withDevice = (title, selectedDevice) =>


### PR DESCRIPTION
## Summary
- import predefined spectral colors for report charts
- supply matching color to spectrum series so chart falls back to palette if undefined

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0417183c083289aed12a0e9944af0