### PR TITLE
Add 515nm spectral color mapping

### DIFF
--- a/src/spectralColors.js
+++ b/src/spectralColors.js
@@ -14,6 +14,7 @@ export const spectralColors = {
   '425nm': '#4169e1',
   '450nm': '#0000ff',
   '475nm': '#00bfff',
+  '515nm': '#32cd32',
   '550nm': '#adff2f',
   '555nm': '#9acd32',
   '600nm': '#ffa500',


### PR DESCRIPTION
## Summary
- add green color mapping for 515nm wavelength in `spectralColors`

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b048ecff3483288207a60a4e620ead