### PR TITLE
Add 515nm spectral color mapping and handle spaced wavelength keys

### DIFF
--- a/src/spectralColors.js
+++ b/src/spectralColors.js
@@ -14,6 +14,7 @@ export const spectralColors = {
   '425nm': '#4169e1',
   '450nm': '#0000ff',
   '475nm': '#00bfff',
+  '515nm': '#32cd32',
   '550nm': '#adff2f',
   '555nm': '#9acd32',
   '600nm': '#ffa500',

--- a/src/utils.js
+++ b/src/utils.js
@@ -28,7 +28,8 @@ export function normalizeSensorData(data) {
 
     if (Array.isArray(data.sensors)) {
         for (const sensor of data.sensors) {
-            const type = sensor.sensorType || sensor.valueType;
+            const rawType = sensor.sensorType || sensor.valueType;
+            const type = typeof rawType === 'string' ? rawType.replace(/\s+/g, '') : rawType;
             const val = Number(sensor.value);
 
             switch (type) {
@@ -107,7 +108,8 @@ export function transformAggregatedData(data) {
     if (!data || !Array.isArray(data.sensors)) return [];
     const map = {};
     for (const sensor of data.sensors) {
-        const sensorType = sensor.sensorType || sensor.valueType;
+        const rawType = sensor.sensorType || sensor.valueType;
+        const sensorType = typeof rawType === 'string' ? rawType.replace(/\s+/g, '') : rawType;
         const unit = sensor.unit || '';
 
         for (const entry of sensor.data || []) {

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -75,7 +75,7 @@ test('normalizes sensors array structure', () => {
             { sensorId: 'as7341-01', sensorType: '445nm', value: 4, unit: 'raw' },
             { sensorId: 'as7341-01', sensorType: '480nm', value: 7, unit: 'raw' },
             { sensorId: 'as7341-01', sensorType: '515nm', value: 9, unit: 'raw' },
-            { sensorId: 'as7341-01', sensorType: '555nm', value: 15, unit: 'raw' },
+            { sensorId: 'as7341-01', sensorType: '555 nm', value: 15, unit: 'raw' },
             { sensorId: 'as7341-01', sensorType: '590nm', value: 24, unit: 'raw' },
             { sensorId: 'as7341-01', sensorType: '630nm', value: 27, unit: 'raw' },
             { sensorId: 'as7341-01', sensorType: '680nm', value: 26, unit: 'raw' },
@@ -162,6 +162,17 @@ test('transformAggregatedData converts API response', () => {
     expect(entry.temperature.value).toBe(27.5);
     expect(entry.F3).toBe(3);
     expect(entry.nir).toBe(10);
+});
+
+test('transformAggregatedData handles spaced wavelength keys', () => {
+    const raw = {
+        sensors: [
+            { sensorType: '555 nm', data: [{ timestamp: '2025-07-25T09:00:04Z', value: 11 }] }
+        ]
+    };
+    const result = transformAggregatedData(raw);
+    expect(result.length).toBe(1);
+    expect(result[0].F5).toBe(11);
 });
 
 test('transformAggregatedData handles valueType and DO sensor', () => {


### PR DESCRIPTION
## Summary
- add green color mapping for 515nm wavelength in `spectralColors`
- normalize sensor type strings so readings like `555 nm` map correctly to their bands
- extend unit tests to cover spaced wavelength keys

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b048ecff3483288207a60a4e620ead