### PR TITLE
Sync All/None filters with parent state

### DIFF
--- a/src/pages/Reports/components/ReportFiltersCompare.jsx
+++ b/src/pages/Reports/components/ReportFiltersCompare.jsx
@@ -147,12 +147,65 @@ export default function ReportFiltersCompare(props) {
         });
     };
 
-    const handleAllSystems = () => setSelectedSystems([...systems]);
-    const handleNoneSystems = () => setSelectedSystems([]);
-    const handleAllLayers  = () => setSelectedLayers([...layers]);
-    const handleNoneLayers = () => setSelectedLayers([]);
-    const handleAllDevices = () => setSelectedDevices([...devices]);
-    const handleNoneDevices= () => setSelectedDevices([]);
+    const handleAllSystems = () => {
+        setSelectedSystems(prev => {
+            systems.forEach(id => {
+                if (!prev.includes(id)) {
+                    onSystemChange && onSystemChange({ target: { value: id } });
+                }
+            });
+            return [...systems];
+        });
+    };
+
+    const handleNoneSystems = () => {
+        setSelectedSystems(prev => {
+            prev.forEach(id => {
+                onSystemChange && onSystemChange({ target: { value: id } });
+            });
+            return [];
+        });
+    };
+
+    const handleAllLayers  = () => {
+        setSelectedLayers(prev => {
+            layers.forEach(id => {
+                if (!prev.includes(id)) {
+                    onLayerChange && onLayerChange({ target: { value: id } });
+                }
+            });
+            return [...layers];
+        });
+    };
+
+    const handleNoneLayers = () => {
+        setSelectedLayers(prev => {
+            prev.forEach(id => {
+                onLayerChange && onLayerChange({ target: { value: id } });
+            });
+            return [];
+        });
+    };
+
+    const handleAllDevices = () => {
+        setSelectedDevices(prev => {
+            devices.forEach(id => {
+                if (!prev.includes(id)) {
+                    onDeviceChange && onDeviceChange({ target: { value: id } });
+                }
+            });
+            return [...devices];
+        });
+    };
+
+    const handleNoneDevices= () => {
+        setSelectedDevices(prev => {
+            prev.forEach(id => {
+                onDeviceChange && onDeviceChange({ target: { value: id } });
+            });
+            return [];
+        });
+    };
 
     // filtered catalog devices according to location selection
     const filteredCatalogDevices = useMemo(() => {

--- a/tests/ReportFiltersCompareAllNone.test.jsx
+++ b/tests/ReportFiltersCompareAllNone.test.jsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import ReportFiltersCompare from '../src/pages/Reports/components/ReportFiltersCompare';
+
+test('All/None selects and deselects systems, layers and devices and notifies parent', async () => {
+  const systems = ['S1', 'S2'];
+  const layers = ['L1', 'L2'];
+  const devices = ['D1', 'D2'];
+  const systemSet = new Set();
+  const layerSet = new Set();
+  const deviceSet = new Set();
+  const toggle = (set) => ({ target: { value } }) => {
+    if (set.has(value)) set.delete(value); else set.add(value);
+  };
+
+  render(
+    <ReportFiltersCompare
+      fromDate=""
+      toDate=""
+      onFromDateChange={() => {}}
+      onToDateChange={() => {}}
+      onApply={() => {}}
+      systems={systems}
+      layers={layers}
+      devices={devices}
+      onSystemChange={toggle(systemSet)}
+      onLayerChange={toggle(layerSet)}
+      onDeviceChange={toggle(deviceSet)}
+      onReset={() => {}}
+      onAddCompare={() => {}}
+      onExportCsv={() => {}}
+      rangeLabel=""
+    />
+  );
+
+  // Systems All -> selects all
+  fireEvent.click(screen.getByLabelText('All', { selector: 'input[name="sys-allnone"]' }));
+  await waitFor(() => {
+    systems.forEach((s) => expect(screen.getByLabelText(s)).toBeChecked());
+  });
+  expect(systemSet.size).toBe(systems.length);
+
+  // Systems None -> clears all
+  fireEvent.click(screen.getByLabelText('None', { selector: 'input[name="sys-allnone"]' }));
+  await waitFor(() => {
+    systems.forEach((s) => expect(screen.getByLabelText(s)).not.toBeChecked());
+  });
+  expect(systemSet.size).toBe(0);
+
+  // Layers All -> selects all
+  fireEvent.click(screen.getByLabelText('All', { selector: 'input[name="lay-allnone"]' }));
+  await waitFor(() => {
+    layers.forEach((l) => expect(screen.getByLabelText(l)).toBeChecked());
+  });
+  expect(layerSet.size).toBe(layers.length);
+
+  // Layers None -> clears all
+  fireEvent.click(screen.getByLabelText('None', { selector: 'input[name="lay-allnone"]' }));
+  await waitFor(() => {
+    layers.forEach((l) => expect(screen.getByLabelText(l)).not.toBeChecked());
+  });
+  expect(layerSet.size).toBe(0);
+
+  // Devices All -> selects all
+  fireEvent.click(screen.getByLabelText('All', { selector: 'input[name="dev-allnone"]' }));
+  await waitFor(() => {
+    devices.forEach((d) => expect(screen.getByLabelText(d)).toBeChecked());
+  });
+  expect(deviceSet.size).toBe(devices.length);
+
+  // Devices None -> clears all
+  fireEvent.click(screen.getByLabelText('None', { selector: 'input[name="dev-allnone"]' }));
+  await waitFor(() => {
+    devices.forEach((d) => expect(screen.getByLabelText(d)).not.toBeChecked());
+  });
+  expect(deviceSet.size).toBe(0);
+});


### PR DESCRIPTION
## Summary
- Ensure All/None handlers for systems, layers and devices notify parent callbacks for each affected ID
- Add tests verifying All/None selections update both local and parent state

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: 6 errors, 11 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b05809bdc08328b2e26ba370244e2d