### PR TITLE
feat: make API base configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,13 @@ The application provides two main views in addition to the default dashboard:
 VITE_MQTT_BROKER_URL=
 VITE_MQTT_USERNAME=
 VITE_MQTT_PASSWORD=
+VITE_API_BASE=
 ```
 
 Additionally, set `VITE_WS_URL` to the WebSocket endpoint that provides the live
 STOMP feed. If not defined, it defaults to `wss://api.hydroleaf.se/ws`.
+Set `VITE_API_BASE` to the base URL for REST API requests in the Reports view.
+When omitted, the Reports page falls back to `https://api.hydroleaf.se`.
 
 These variables are used to establish the MQTT connection.
 Make sure the file is named `.env` and each variable starts with the `VITE_` prefix so that Vite exposes them to the frontend.

--- a/src/pages/Reports/index.jsx
+++ b/src/pages/Reports/index.jsx
@@ -13,7 +13,7 @@ const toLocalInputValue = (date) => {
 };
 const toISOSeconds = (v) => (v ? new Date(v).toISOString() : "");
 const AUTO_REFRESH_MS = {"30s": 30_000, "1m": 60_000, "5m": 300_000};
-const API_BASE = "https://api.hydroleaf.se";
+const API_BASE = import.meta.env.VITE_API_BASE ?? "https://api.hydroleaf.se";
 
 // English: choose bucket by range. Min resolution is 1m (your sampling rate)
 const pickBucket = (fromLocal, toLocal) => {


### PR DESCRIPTION
## Summary
- make reports API base URL configurable via `VITE_API_BASE`
- document `VITE_API_BASE` environment variable

## Testing
- `npm test`
- `npm run lint` *(fails: parseIds defined but never used; empty block statements in useStomp.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b05851eccc8328b5a286f49811cd60