### PR TITLE
Normalize CO₂ metrics in dashboard

### DIFF
--- a/src/hooks/useLiveNow.js
+++ b/src/hooks/useLiveNow.js
@@ -8,8 +8,9 @@ export function useLiveNow() {
 
     const normalize = (payload) => {
         const out = {};
+        const fixSubs = (s) => String(s).replace(/[₀₁₂₃₄₅₆₇₈₉]/g, (d) => "0123456789"["₀₁₂₃₄₅₆₇₈₉".indexOf(d)]);
         for (const [k, v] of Object.entries(payload || {})) {
-            const key = k.replace(/[\s_-]/g, "").toLowerCase();
+            const key = fixSubs(k).replace(/[\s_-]/g, "").toLowerCase();
             out[key] = v;
         }
         return out;

--- a/src/hooks/useStomp.js
+++ b/src/hooks/useStomp.js
@@ -23,6 +23,7 @@ function attachReconnect(client) {
             try {
                 fn();
             } catch {
+                /* ignore */
             }
         });
         prevOnConnect?.(frame);
@@ -47,6 +48,7 @@ function ensureClient(opts = {}) {
                 try {
                     fn();
                 } catch {
+                    /* ignore */
                 }
             }), 0);
         }
@@ -62,6 +64,7 @@ function ensureClient(opts = {}) {
         heartbeatIncoming: opts.heartbeatIncoming ?? 10000,
         heartbeatOutgoing: opts.heartbeatOutgoing ?? 10000,
         debug: () => {
+            /* no-op */
         },
     });
     attachReconnect(sharedClient);
@@ -105,6 +108,7 @@ export function useStomp(topics, onMessage, opts = {}) {
                         try {
                             payload = typeof payload === "string" ? JSON.parse(payload) : payload;
                         } catch {
+                            /* ignore */
                         }
                         const topicName = dest.startsWith("/topic/") ? dest.slice(7) : dest;
                         handlerRef.current?.(topicName, payload);
@@ -118,6 +122,7 @@ export function useStomp(topics, onMessage, opts = {}) {
                     try {
                         subsRef.current[dest].unsubscribe?.();
                     } catch {
+                        /* ignore */
                     }
                     delete subsRef.current[dest];
                 }
@@ -132,6 +137,7 @@ export function useStomp(topics, onMessage, opts = {}) {
                 try {
                     s.unsubscribe?.();
                 } catch {
+                    /* ignore */
                 }
             });
             subsRef.current = {};

--- a/src/pages/Dashboard/components/DashboardV2.jsx
+++ b/src/pages/Dashboard/components/DashboardV2.jsx
@@ -21,6 +21,8 @@ const normLayerId = (l) => {
     return m ? `L${String(m[1]).padStart(2, "0")}` : (raw || "--");
 };
 
+const fixSubs = (s) => String(s).replace(/[₀₁₂₃₄₅₆₇₈₉]/g, (d) => "0123456789"["₀₁₂₃₄₅₆₇₈₉".indexOf(d)]);
+
 function getMetric(obj, key) {
     if (!obj) return null;
     const val = obj[key] ?? obj[key?.toLowerCase()] ?? obj[key?.toUpperCase()];
@@ -57,7 +59,7 @@ const sensorLabel = (k) => ({
 }[k] || k);
 
 function canonKey(raw) {
-    const t = String(raw || "").toLowerCase();
+    const t = fixSubs(String(raw || "")).toLowerCase();
     if (!t) return null;
     if (t === "light") return "light";
     if (t === "temperature" || t === "temp") return "temperature";
@@ -132,11 +134,6 @@ function useLayerCompositeCards(systemKeyInput, layerId) {
     const [cards, setCards] = React.useState({});
     const layerKey = String(layerId || "").toUpperCase();
     const sysKey = String(systemKeyInput || "").toUpperCase();
-
-    function parseIds(compId) {
-        const parts = String(compId || '').split('-');
-        return {system: (parts[0] || '').toUpperCase(), layer: (parts[1] || '').toUpperCase()};
-    }
 
     const isMine = React.useCallback((compId, data) => {
         const cid = String(compId || "").trim().toUpperCase();

--- a/tests/useLiveNow.test.jsx
+++ b/tests/useLiveNow.test.jsx
@@ -13,9 +13,10 @@ test('captures live_now updates and normalizes keys', () => {
   const { result } = renderHook(() => useLiveNow());
 
   act(() => {
-    global.__liveNowHandler('live_now', { Systems: {}, 'Last Update': 123 });
+    global.__liveNowHandler('live_now', { Systems: {}, 'Last Update': 123, 'CO₂': 400 });
   });
 
   expect(result.current).toHaveProperty('systems');
   expect(result.current).toHaveProperty('lastupdate');
+  expect(result.current).toHaveProperty('co2');
 });


### PR DESCRIPTION
## Summary
- Normalize sensor keys like `CO₂` to `co2` when receiving live data
- Ensure dashboard canonicalization handles subscript digits
- Add regression test for CO₂ key normalization

## Testing
- `npx vitest run`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b2407479c083289e7524bfb5510f07