### PR TITLE
feat: add DeviceCard component

### DIFF
--- a/src/components/DeviceCard.jsx
+++ b/src/components/DeviceCard.jsx
@@ -1,0 +1,30 @@
+import React from "react";
+import styles from "./DeviceCard.module.css";
+
+/**
+ * Simple card for displaying sensor readings of a device.
+ *
+ * Props:
+ * - compositeId: string identifying the device (e.g., "S1-L1-D1")
+ * - sensors: Array<{ sensorType: string; value: number|string; unit?: string }>
+ */
+function DeviceCard({ compositeId, sensors = [] }) {
+  return (
+    <div className={styles.card} data-testid="device-card">
+      <div className={styles.title}>{compositeId}</div>
+      <ul className={styles.list}>
+        {sensors.map((s) => (
+          <li key={s.sensorType}>
+            <span>{s.sensorType}</span>
+            <b>
+              {s.value}
+              {s.unit ? ` ${s.unit}` : ""}
+            </b>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default React.memo(DeviceCard);

--- a/src/components/DeviceCard.module.css
+++ b/src/components/DeviceCard.module.css
@@ -1,0 +1,20 @@
+.card {
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 8px;
+  margin: 4px 0;
+}
+.title {
+  font-weight: bold;
+  margin-bottom: 4px;
+}
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.list li {
+  display: flex;
+  justify-content: space-between;
+  padding: 2px 0;
+}

--- a/src/pages/Dashboard/components/DashboardV2.jsx
+++ b/src/pages/Dashboard/components/DashboardV2.jsx
@@ -2,6 +2,7 @@
 import React, {useState, useMemo} from "react";
 import {useLiveNow} from "../../../hooks/useLiveNow";
 import {useStomp} from "../../../hooks/useStomp";
+import DeviceCard from "../../../components/DeviceCard";
 import styles from "./DashboardV2.module.css";
 
 // ---------- utils ----------
@@ -237,19 +238,15 @@ function LayerCard({layer, systemId}) {
                         <div className={styles.devCards}>
                             {deviceCards.length ? (
                                 deviceCards.map((card) => (
-                                    <div key={card.compId} className={styles.devCard}>
-                                        <div className={styles.devTitle}>{card.compId}</div>
-                                        <ul className={styles.devList}>
-                                            {Object.entries(card.sensors).map(([k, v]) => (
-                                                <li key={k}>
-                                                    <span>{sensorLabel(k)}</span>
-                                                    <b>
-                                                        {fmt(v?.value)} {v?.unit || ""}
-                                                    </b>
-                                                </li>
-                                            ))}
-                                        </ul>
-                                    </div>
+                                    <DeviceCard
+                                        key={card.compId}
+                                        compositeId={card.compId}
+                                        sensors={Object.entries(card.sensors).map(([k, v]) => ({
+                                            sensorType: sensorLabel(k),
+                                            value: fmt(v?.value),
+                                            unit: v?.unit || "",
+                                        }))}
+                                    />
                                 ))
                             ) : (
                                 <div className={styles.muted}>No device cards</div>

--- a/src/pages/Dashboard/components/DashboardV2.module.css
+++ b/src/pages/Dashboard/components/DashboardV2.module.css
@@ -104,11 +104,6 @@
 
 /* device composite cards */
 .devCards { display:grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap:10px; }
-.devCard { border:1px solid #e5e7eb; border-radius:10px; padding:10px; background:#fff; }
-.devTitle { font-weight:700; margin-bottom:6px; font-size:.95rem; }
-.devList { list-style:none; margin:0; padding:0; }
-.devList li { display:flex; justify-content:space-between; padding:4px 0; border-bottom:1px dashed #f0f0f0; }
-.devList li:last-child { border-bottom:none; }
 
 .divider {
     height: 1px;

--- a/tests/DeviceCard.test.jsx
+++ b/tests/DeviceCard.test.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import DeviceCard from '../src/components/DeviceCard.jsx';
+
+test('renders composite id and sensor readings', () => {
+  const sensors = [
+    { sensorType: 'temperature', value: 22.5, unit: '°C' },
+    { sensorType: 'humidity', value: 55, unit: '%' }
+  ];
+
+  render(<DeviceCard compositeId="S1-L1-D1" sensors={sensors} />);
+
+  expect(screen.getByText('S1-L1-D1')).toBeInTheDocument();
+  expect(screen.getByText('temperature')).toBeInTheDocument();
+  expect(screen.getByText('22.5 °C')).toBeInTheDocument();
+  expect(screen.getByText('humidity')).toBeInTheDocument();
+  expect(screen.getByText('55 %')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add reusable DeviceCard component for displaying sensor readings
- style DeviceCard with basic CSS module
- test DeviceCard rendering

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b49425ba348328926f048bddf2c475