### PR TITLE
Reposition environment card and rename

### DIFF
--- a/src/pages/Dashboard/components/DashboardV2.jsx
+++ b/src/pages/Dashboard/components/DashboardV2.jsx
@@ -319,24 +319,22 @@ export default function DashboardV2() {
                             </div>
                         </div>
                     </div>
-                    <div className={styles.col6}>
-                        <div className={`${styles.subcard} ${styles.env}`}>
-                            <h3>Environment</h3>
-                            <div className={styles.stats}>
-                                {ENV_STATS.map(({label, key, precision}) => (
-                                    <Stat
-                                        key={key}
-                                        label={`${label} (${getCount(active.env, key)} sensors)`}
-                                        value={fmt(getMetric(active.env, key), precision)}
-                                    />
-                                ))}
-                            </div>
-                        </div>
-                    </div>
                 </div>
                 <div className={styles.divider}/>
                 <div className={styles.section}>
                     <h3 className={styles.muted}>Layers</h3>
+                    <div className={`${styles.subcard} ${styles.env}`}>
+                        <h3>Environment overview</h3>
+                        <div className={styles.stats}>
+                            {ENV_STATS.map(({label, key, precision}) => (
+                                <Stat
+                                    key={key}
+                                    label={`${label} (${getCount(active.env, key)} sensors)`}
+                                    value={fmt(getMetric(active.env, key), precision)}
+                                />
+                            ))}
+                        </div>
+                    </div>
                     <div className={styles.layers}>
                         {active.layers.map(l => (<LayerCard key={l.id} layer={l} systemId={active.id}/>))}
                     </div>

--- a/src/pages/Dashboard/components/DashboardV2.module.css
+++ b/src/pages/Dashboard/components/DashboardV2.module.css
@@ -162,7 +162,7 @@
 
 /* explicit labels */
 .subcard.water::before { content: "System · Water"; }
-.subcard.env::before   { content: "System · Environment"; }
+.subcard.env::before   { content: "Environment overview"; }
 
 /* layer look */
 .layer {


### PR DESCRIPTION
## Summary
- move System · Environment card below water metrics and just above layers list
- rename card header to Environment overview

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4bdf794d083289189ea1567fcee4d