### PR TITLE
feat: show water device cards under system water

### DIFF
--- a/tests/isWaterDevice.test.jsx
+++ b/tests/isWaterDevice.test.jsx
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { isWaterDevice } from '../src/pages/Dashboard/components/DashboardV2.jsx';
+
+describe('isWaterDevice', () => {
+  it('detects water device IDs', () => {
+    expect(isWaterDevice('S01-L01-T01')).toBe(true);
+    expect(isWaterDevice('S01-L01-D01')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- classify composite IDs ending with a T segment as water sensors
- surface water sensor device cards in the system water section while hiding them from layers
- test helper for detecting water devices

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b4c05f72208328a0339661c26b3a8c