### PR TITLE
Highlight out-of-range dashboard values

### DIFF
--- a/src/pages/Live/components/Overview.module.css
+++ b/src/pages/Live/components/Overview.module.css
@@ -26,8 +26,8 @@
 
 /* State colors */
 .ok { background: linear-gradient(180deg, #065f46 0%, #064e3b 100%); }      /* emerald */
-.warn { background: linear-gradient(180deg, #92400e 0%, #7c2d12 100%); }    /* amber */
-.danger { background: linear-gradient(180deg, #7f1d1d 0%, #450a0a 100%); }  /* red */
+.warn { background: #fff3cd; color: #000; }    /* light yellow */
+.danger { background: #f8d7da; color: #000; }  /* light red */
 .neutral { background: linear-gradient(180deg, #374151 0%, #1f2937 100%); } /* slate */
 
 @media (max-width: 480px) {

--- a/src/pages/Live/components/SensorDashboard/index.jsx
+++ b/src/pages/Live/components/SensorDashboard/index.jsx
@@ -8,6 +8,7 @@ import Live from "../Live";
 import {SENSOR_TOPIC, topics} from "../../../common/dashboard.constants.js";
 import {useFilters, ALL} from "../../../../context/FiltersContext";
 import Overview from "../Overview";
+import idealRangeConfig from "../../../../idealRangeConfig.js";
 
 function SensorDashboard({ view, title = '' }) {
     const [activeSystem, setActiveSystem] = useState("S01");
@@ -126,6 +127,7 @@ function SensorDashboard({ view, title = '' }) {
                 unit: metric("light").average != null ? "lx" : "",
                 title: "Light",
                 subtitle: `Composite IDs: ${metric("light").deviceCount ?? 0}`,
+                range: idealRangeConfig.lux?.idealRange,
             },
             {
                 key: "temperature",
@@ -134,6 +136,7 @@ function SensorDashboard({ view, title = '' }) {
                 unit: metric("temperature").average != null ? "℃" : "",
                 title: "Temperature",
                 subtitle: `Composite IDs: ${metric("temperature").deviceCount ?? 0}`,
+                range: idealRangeConfig.temperature?.idealRange,
             },
             {
                 key: "humidity",
@@ -142,6 +145,7 @@ function SensorDashboard({ view, title = '' }) {
                 unit: metric("humidity").average != null ? "%" : "",
                 title: "Humidity",
                 subtitle: `Composite IDs: ${metric("humidity").deviceCount ?? 0}`,
+                range: idealRangeConfig.humidity?.idealRange,
             },
             {
                 key: "dissolvedOxygen",
@@ -150,6 +154,7 @@ function SensorDashboard({ view, title = '' }) {
                 unit: metric("dissolvedOxygen").average != null ? "mg/L" : "",
                 title: "DO",
                 subtitle: `Composite IDs: ${metric("dissolvedOxygen").deviceCount ?? 0}`,
+                range: idealRangeConfig.dissolvedOxygen?.idealRange,
             },
         ];
 


### PR DESCRIPTION
## Summary
- color overview boxes based on ideal sensor ranges
- mark borderline values in yellow and out-of-range values in light red

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4c9f70218832896696c3f1538f41b