### PR TITLE
Add CO₂ metric to system and layer cards

### DIFF
--- a/src/pages/Dashboard/normalizeLiveNow.js
+++ b/src/pages/Dashboard/normalizeLiveNow.js
@@ -47,6 +47,7 @@ export function normalizeLiveNow(payload) {
             const {avg: lux, count: lightCount} = getMetric(env, "light");
             const {avg: temp, count: tempCount} = getMetric(env, "temperature");
             const {avg: humidity, count: humidityCount} = getMetric(env, "humidity");
+            const {avg: co2, count: co2Count} = getMetric(env, "co2", "co₂", "co2ppm");
 
             const {avg: dTemp, count: dTempCount} = getMetric(water, "dissolvedTemp");
             const {avg: DO, count: DOCount} = getMetric(water, "dissolvedOxygen");
@@ -57,10 +58,10 @@ export function normalizeLiveNow(payload) {
             const {avg: airPumpAvg, count: airPumpCount} = getMetric(acts, "airpump");
             const airPump = airPumpAvg == null ? null : airPumpAvg >= 0.5;
 
-            const hasAny = [lux, temp, humidity, dTemp, DO, pH, EC, TDS, airPumpAvg].some(
+            const hasAny = [lux, temp, humidity, co2, dTemp, DO, pH, EC, TDS, airPumpAvg].some(
                 (v) => v != null
             );
-            const missingEnv = [lux, temp, humidity].some((v) => v == null);
+            const missingEnv = [lux, temp, humidity, co2].some((v) => v == null);
             const health = !hasAny ? "down" : missingEnv ? "warn" : "ok";
 
             layerCards.push({
@@ -70,10 +71,12 @@ export function normalizeLiveNow(payload) {
                     lux: lux ?? null,
                     temp: temp ?? null,
                     humidity: humidity ?? null,
+                    co2: co2 ?? null,
                     _counts: {
                         light: lightCount,
                         temperature: tempCount,
                         humidity: humidityCount,
+                        co2: co2Count,
                     },
                 },
                 water: {
@@ -100,10 +103,8 @@ export function normalizeLiveNow(payload) {
         const sysEnv = sys.environment ?? {};
         const {avg: lightAvg, count: lightCount} = getMetric(sysEnv, "light");
         const {avg: humidityAvg, count: humidityCount} = getMetric(sysEnv, "humidity");
-        const {avg: tempAvg, count: tempCount} = getMetric(
-            sysEnv,
-            "temperature"
-        );
+        const {avg: tempAvg, count: tempCount} = getMetric(sysEnv, "temperature");
+        const {avg: co2Avg, count: co2Count} = getMetric(sysEnv, "co2", "co₂", "co2ppm");
 
         const sysWater = sys.water ?? {};
         const {avg: dTempAvg, count: dTempCount} = getMetric(
@@ -145,6 +146,7 @@ export function normalizeLiveNow(payload) {
                 light: lightAvg ?? null,
                 humidity: humidityAvg ?? null,
                 temperature: tempAvg ?? null,
+                co2: co2Avg ?? null,
                 dissolvedTemp: dTempAvg ?? null,
                 dissolvedOxygen: DOavg ?? null,
                 dissolvedEC: ECavg ?? null,
@@ -155,6 +157,7 @@ export function normalizeLiveNow(payload) {
                     light: lightCount,
                     humidity: humidityCount,
                     temperature: tempCount,
+                    co2: co2Count,
                     dissolvedTemp: dTempCount,
                     dissolvedOxygen: DOcount,
                     dissolvedEC: ECcount,

--- a/src/pages/SystemAndLayerCards/index.jsx
+++ b/src/pages/SystemAndLayerCards/index.jsx
@@ -117,10 +117,11 @@ export function SystemOverviewCard({
                     <MetricCard compact title="pH" value={fmt(metrics.pH, 1)} icon={<span>⚗️</span>} subtitle={metrics?._counts?.pH != null ? `Composite IDs: ${metrics._counts.pH}` : undefined} />
                     <MetricCard compact title="Air Pump" value={metrics.airPump ? "On" : "Off"} icon={<span>🫧</span>} subtitle={metrics?._counts?.airPump != null ? `Composite IDs: ${metrics._counts.airPump}` : undefined} />
                 </div>
-                <div className={cx("metrics-group")}> 
+                <div className={cx("metrics-group")}>
                     <MetricCard compact title="Light" value={fmt(metrics.light, 1)} unit="lux" icon={<span>☀️</span>} subtitle={metrics?._counts?.light != null ? `Composite IDs: ${metrics._counts.light}` : undefined} />
                     <MetricCard compact title="Humidity" value={fmt(metrics.humidity, 1)} unit="%" icon={<span>%</span>} subtitle={metrics?._counts?.humidity != null ? `Composite IDs: ${metrics._counts.humidity}` : undefined} />
                     <MetricCard compact title="Temperature" value={fmt(metrics.temperature, 1)} unit="°C" icon={<span>🌡️</span>} subtitle={metrics?._counts?.temperature != null ? `Composite IDs: ${metrics._counts.temperature}` : undefined} />
+                    <MetricCard compact title="CO₂" value={fmt(metrics.co2, 0)} unit="ppm" icon={<span>CO₂</span>} subtitle={metrics?._counts?.co2 != null ? `Composite IDs: ${metrics._counts.co2}` : undefined} />
                 </div>
             </div>
         </div>
@@ -145,10 +146,11 @@ export function LayerPanel({id, health, metrics, water = {}, actuators = {}, chi
                     <MetricCard compact title="TDS" value={fmt(water.dissolvedTDS, 0)} unit="ppm" icon={<span>💧</span>} subtitle={water?._counts?.dissolvedTDS != null ? `Composite IDs: ${water._counts.dissolvedTDS}` : undefined} />
                     <MetricCard compact title="Air Pump" value={actuators.airPump ? "On" : "Off"} icon={<span>🫧</span>} subtitle={actuators?._counts?.airPump != null ? `Composite IDs: ${actuators._counts.airPump}` : undefined} />
                 </div>
-                <div className={cx("metrics-group")}> 
+                <div className={cx("metrics-group")}>
                     <MetricCard compact title="Light" value={fmt(metrics.lux, 1)} unit="lx" icon={<span>☀️</span>} subtitle={metrics?._counts?.light != null ? `Composite IDs: ${metrics._counts.light}` : undefined} />
                     <MetricCard compact title="Temperature" value={fmt(metrics.temp, 1)} unit="°C" icon={<span>🌡️</span>} subtitle={metrics?._counts?.temperature != null ? `Composite IDs: ${metrics._counts.temperature}` : undefined} />
                     <MetricCard compact title="Humidity" value={fmt(metrics.humidity, 1)} unit="%" icon={<span>%</span>} subtitle={metrics?._counts?.humidity != null ? `Composite IDs: ${metrics._counts.humidity}` : undefined} />
+                    <MetricCard compact title="CO₂" value={fmt(metrics.co2, 0)} unit="ppm" icon={<span>CO₂</span>} subtitle={metrics?._counts?.co2 != null ? `Composite IDs: ${metrics._counts.co2}` : undefined} />
                 </div>
             </div>
 

--- a/tests/DashboardNormalize.test.jsx
+++ b/tests/DashboardNormalize.test.jsx
@@ -15,7 +15,8 @@ const samplePayload = {
       environment: {
         light: { average: 12, deviceCount: 1 },
         humidity: { average: 55, deviceCount: 1 },
-        temperature: { average: 25, deviceCount: 1 }
+        temperature: { average: 25, deviceCount: 1 },
+        co2: { average: 400, deviceCount: 1 }
       },
       water: {
         dissolvedTemp: { average: 20, deviceCount: 1 },
@@ -33,7 +34,8 @@ const samplePayload = {
           environment: {
             light: { average: 15, deviceCount: 1 },
             temperature: { average: 22, deviceCount: 1 },
-            humidity: { average: 60, deviceCount: 1 }
+            humidity: { average: 60, deviceCount: 1 },
+            co2: { average: 405, deviceCount: 1 }
           },
           water: {
             dissolvedTemp: { average: 21, deviceCount: 1 },
@@ -68,8 +70,10 @@ describe('normalizeLiveNow', () => {
     expect(sys.metrics.light).toBe(12);
     expect(sys.metrics.humidity).toBe(55);
     expect(sys.metrics.temperature).toBe(25);
+    expect(sys.metrics.co2).toBe(400);
     expect(sys.metrics.airPump).toBe(true);
     expect(sys.metrics._counts.light).toBe(1);
+    expect(sys.metrics._counts.co2).toBe(1);
     // layer summary counts
     expect(sys.layers).toHaveLength(2);
     expect(sys.layers.map(l => l.id)).toEqual(['L01', 'L02']);
@@ -79,10 +83,12 @@ describe('normalizeLiveNow', () => {
     const layer1 = sys._layerCards[0];
     expect(layer1.metrics.lux).toBe(15);
     expect(layer1.metrics.humidity).toBe(60);
+    expect(layer1.metrics.co2).toBe(405);
     expect(layer1.water.pH).toBe(7);
     expect(layer1.actuators.airPump).toBe(true);
     // counts propagate
     expect(layer1.metrics._counts.light).toBe(1);
+    expect(layer1.metrics._counts.co2).toBe(1);
     const layer2 = sys._layerCards[1];
     expect(layer2.id).toBe('L02');
     expect(layer2.metrics.lux).toBe(null);


### PR DESCRIPTION
## Summary
- include CO₂ readings when normalizing live_now payloads
- display average CO₂ on system overview and layer cards
- test CO₂ mapping in normalizeLiveNow

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68b4d677a6248328ace250b3a71dc24b