### PR TITLE
Ensure CO₂ row appears on device cards

### DIFF
--- a/src/pages/Dashboard/components/DeviceCard.jsx
+++ b/src/pages/Dashboard/components/DeviceCard.jsx
@@ -130,7 +130,7 @@ export default function DeviceCard({
           <div className={styles.badge}>{name}</div>
         </div>
 
-        {co2 != null && line("CO₂", `${fmt(co2)} ppm`)}
+        {line("CO₂", `${fmt(co2)} ppm`)}
 
         {line("[Temp, Humidity]", `[${fmt(t)} °C, ${fmt(h)} %]`)}
 


### PR DESCRIPTION
## Summary
- Always render the CO₂ row in `DeviceCard` so missing values show `-- ppm`

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4d930a6bc8328b4e552ec4770ec5b