### PR TITLE
refactor: remove hook re-exports and use shared hooks directly

### DIFF
--- a/src/components/useHistory.js
+++ b/src/components/useHistory.js
@@ -1,1 +1,0 @@
-export { useHistory } from '../pages/common/useHistory.js';

--- a/src/components/useLiveDevices.js
+++ b/src/components/useLiveDevices.js
@@ -1,1 +1,0 @@
-export { useLiveDevices } from '../pages/common/useLiveDevices.js';

--- a/src/pages/Live/components/SensorDashboard/index.jsx
+++ b/src/pages/Live/components/SensorDashboard/index.jsx
@@ -1,7 +1,7 @@
 // SensorDashboard.jsx
 import React, {useEffect, useMemo, useState} from "react";
 import Header from "../../../common/Header";
-import { useLiveDevices } from "../../../../components/useLiveDevices.js";
+import { useLiveDevices } from "../../../common/useLiveDevices.js";
 import { useLiveNow } from "../../../../hooks/useLiveNow";
 import styles from "../../../common/SensorDashboard.module.css";
 import Live from "../Live";


### PR DESCRIPTION
## Summary
- remove legacy `useHistory` and `useLiveDevices` re-export hooks
- use `useLiveDevices` from `pages/common` in the live sensor dashboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b61a5c84d0832888d29e4a671efd5c