### PR TITLE
refactor: modularize dashboard utilities and components

### DIFF
--- a/src/pages/Dashboard/components/DashboardV2.jsx
+++ b/src/pages/Dashboard/components/DashboardV2.jsx
@@ -1,368 +1,13 @@
 // src/pages/Dashboard/DashboardV2.jsx
 import React, {useState, useMemo} from "react";
 import {useLiveNow} from "../../../hooks/useLiveNow";
-import {useStomp} from "../../../hooks/useStomp";
 import DeviceCard from "./DeviceCard.jsx";
 import styles from "./DashboardV2.module.css";
 import idealRangeConfig from "../../../idealRangeConfig.js";
-import clsx from "clsx";
-
-// ---------- utils ----------
-const toNum = (v) => (v == null || v === "" ? null : Number(v));
-const fmt = (v, d = 1) => (v == null || Number.isNaN(v) ? "--" : Number(v).toFixed(d));
-const localDateTime = (ms) => {
-    try {
-        return ms ? new Date(ms).toLocaleString() : "--";
-    } catch {
-        return "--";
-    }
-};
-const normLayerId = (l) => {
-    const raw = l?.id ?? l?.layerId ?? "";
-    if (/^L\d+$/i.test(raw)) return raw.toUpperCase();
-    const m = /^layer(\d+)$/i.exec(raw || "");
-    return m ? `L${String(m[1]).padStart(2, "0")}` : (raw || "--");
-};
-
-const fixSubs = (s) => String(s).replace(/[₀₁₂₃₄₅₆₇₈₉]/g, (d) => "0123456789"["₀₁₂₃₄₅₆₇₈₉".indexOf(d)]);
-
-function getMetric(obj, key) {
-    if (!obj) return null;
-    const val = obj[key] ?? obj[key?.toLowerCase()] ?? obj[key?.toUpperCase()];
-    if (val == null) return null;
-    return typeof val === "object" ? toNum(val.average ?? val.avg ?? val.value) : toNum(val);
-}
-
-function getCount(obj, key) {
-    if (!obj) return 0;
-    const v = obj[key] ?? obj[key?.toLowerCase()] ?? obj[key?.toUpperCase()];
-    if (v && typeof v === "object") {
-        const n = v.deviceCount ?? v.count ?? v.sensorCount;
-        return typeof n === "number" ? n : 0;
-    }
-    return v != null ? 1 : 0;
-}
-
-function deriveHealth(layer) {
-    const e = layer.environment || {};
-    const present = ["light", "temperature", "humidity"].map(k => getMetric(e, k)).filter(v => v != null).length;
-    return present === 0 ? "down" : present < 3 ? "warn" : "ok";
-}
-
-// websocket sensor key mapping
-const sensorLabel = (k) => ({
-    light: "Light",
-    temperature: "Temp",
-    humidity: "Humidity",
-    pH: "pH",
-    dissolvedTemp: "Water Temp",
-    dissolvedOxygen: "DO",
-    dissolvedEC: "EC",
-    dissolvedTDS: "TDS"
-}[k] || k);
-
-function canonKey(raw) {
-    const t = fixSubs(String(raw || "")).toLowerCase();
-    if (!t) return null;
-    if (t === "light") return "light";
-    if (t === "temperature" || t === "temp") return "temperature";
-    if (t === "humidity" || t === "hum") return "humidity";
-    if (t === "co2" || t === "co₂" || t === "co2ppm") return "co2";   // ← اضافه شد
-    if (t === "ph") return "pH";
-    if (t === "do" || t === "dissolvedoxygen") return "dissolvedOxygen";
-    if (t === "ec" || t === "dissolvedec") return "dissolvedEC";
-    if (t === "tds" || t === "dissolvedtds") return "dissolvedTDS";
-    if (t === "watertemp" || t === "dissolvedtemp") return "dissolvedTemp";
-    return raw;
-}
-
-function normalizeSensors(src) {
-    const out = {};
-    if (!src) return out;
-    if (Array.isArray(src)) {
-        for (const s of src) {
-            const k = canonKey(s?.sensorType ?? s?.type ?? s?.name);
-            const val = toNum(s?.value);
-            const unit = s?.unit || s?.units || s?.u;
-            if (k && val != null) out[k] = {value: val, unit};
-        }
-        return out;
-    }
-    if (typeof src === "object") {
-        for (const [k, v] of Object.entries(src)) {
-            const key = canonKey(k);
-            if (v && typeof v === "object") {
-                const val = toNum(v.value ?? v.avg ?? v.average ?? v.v);
-                const unit = v.unit || v.u;
-                if (val != null) out[key] = {value: val, unit};
-            } else if (v != null) {
-                out[key] = {value: toNum(v)};
-            }
-        }
-    }
-    return out;
-}
-
-// ---------- small UI pieces ----------
-function aggregateFromCards(cards) {
-  const keys = ["light", "temperature", "humidity", "pH", "co2"]; // ← co2 اضافه شد
-  const sums = {}, counts = {};
-    for (const c of cards || []) {
-        const s = c?.sensors || {};
-        for (const k of keys) {
-            const v = s[k]?.value;
-            const n = v == null ? null : Number(v);
-            if (n != null && !Number.isNaN(n)) {
-                sums[k] = (sums[k] || 0) + n;
-                counts[k] = (counts[k] || 0) + 1;
-            }
-        }
-    }
-    const avg = {};
-  Object.keys(sums).forEach(k => (avg[k] = sums[k] / counts[k]));
-    return {avg, counts};
-}
-
-function Stat({label, value, range}) {
-    const numeric = typeof value === "number" ? value : parseFloat(String(value).replace(",", "."));
-    let state = null;
-    if (range && typeof numeric === "number" && !Number.isNaN(numeric)) {
-        const {min, max} = range;
-        if (typeof min === "number" && typeof max === "number") {
-            const threshold = (max - min) * 0.1;
-            if (numeric < min || numeric > max) state = "danger";
-            else if (numeric < min + threshold || numeric > max - threshold) state = "warn";
-            else state = "ok";
-        }
-    }
-    return (
-        <div
-            className={clsx(
-                styles.stat,
-                state === "ok" && styles.statOk,
-                state === "warn" && styles.statWarn,
-                state === "danger" && styles.statDanger
-            )}
-        >
-            <strong>{value}</strong>
-            <span className={styles.muted}>{label}</span>
-        </div>
-    );
-}
-
-function MetricLine({label, value, count, unit}) {
-    return (<div className={styles.kv}>
-        <span>{label}</span><b>{fmt(value)} {unit} {count > 0 ? `(${count} sensors)` : ""}</b></div>);
-}
-
-// metric configs used to render sensor stats
-const WATER_STATS = [
-    {label: "pH", key: "pH", alt: "ph", precision: 1, rangeKey: "ph"},
-    {label: "DO", key: "dissolvedOxygen", precision: 1, rangeKey: "dissolvedOxygen"},
-    {label: "EC", key: "dissolvedEC", precision: 2, rangeKey: "ec"},
-    {label: "TDS", key: "dissolvedTDS", precision: 0, rangeKey: "tds"},
-    {label: "Temp", key: "dissolvedTemp", precision: 1, rangeKey: "temperature"}
-];
-
-const ENV_STATS = [
-    {label: "Light", key: "light", precision: 1, rangeKey: "lux"},
-    {label: "Temp", key: "temperature", precision: 1, rangeKey: "temperature"},
-    {label: "Humidity", key: "humidity", precision: 0, rangeKey: "humidity"},
-    {label: "CO₂", key: "co2", precision: 0}
-];
-
-// identify water sensors by device id starting with 'T'
-// eslint-disable-next-line react-refresh/only-export-components
-export function isWaterDevice(compId) {
-    const parts = String(compId || "").trim().toUpperCase().split("-");
-    return parts[2]?.startsWith("T") || false;
-}
-
-// subscribe to websockets and build composite cards per layer
-function useLayerCompositeCards(systemKeyInput, layerId) {
-    const [cards, setCards] = React.useState({});
-    const layerKey = String(layerId || "").toUpperCase();
-    const sysKey = String(systemKeyInput || "").toUpperCase();
-
-    const isMine = React.useCallback((compId, data) => {
-        const cid = String(compId || "").trim().toUpperCase();
-        if (cid) {
-            if (!cid.startsWith(`${sysKey}-`)) return false;
-            if (!cid.includes(`-${layerKey}-`)) return false;
-            return true;
-        }
-        const sys = String(data?.system || data?.systemId || "").trim().toUpperCase();
-        const lay = String(data?.layer || data?.layerId || "").trim().toUpperCase();
-        if (sysKey && sys && sys !== sysKey) return false;
-        if (layerKey && lay && lay !== layerKey) return false;
-        return !!sys && !!lay;
-    }, [sysKey, layerKey]);
-
-    const upsert = React.useCallback((compId, sensors, ts) => {
-        setCards(prev => {
-            const next = {...prev};
-            const cur = next[compId] || {sensors: {}, ts: 0};
-            const normalized = normalizeSensors(sensors);
-            for (const [k, obj] of Object.entries(normalized)) {
-                cur.sensors[k] = {value: obj.value, unit: obj.unit};
-            }
-            cur.ts = Math.max(cur.ts || 0, ts || Date.now());
-            next[compId] = cur;
-            return next;
-        });
-    }, []);
-
-    const topics = React.useMemo(() => ["/topic/growSensors", "/topic/waterTank"], []); // stable reference
-    useStomp(topics, (topic, data) => {
-        if (!data) return;
-        let compId = data.compositeId || data.composite_id || data.cid;
-        if (!compId) {
-            const sys = data.system || data.systemId;
-            const lay = data.layer || data.layerId;
-            const dev = data.deviceId || data.device || data.devId;
-            if (sys && lay && dev) compId = `${sys}-${lay}-${dev}`;
-        }
-        if (!compId) return;
-        if (!isMine(compId, data)) return;
-        const sensors = data.sensors || data.values || data.env || data.water || data.payload || data.readings || [];
-        upsert(compId, sensors, data.timestamp || data.ts);
-    });
-
-    React.useEffect(() => {
-        setCards({});
-    }, [sysKey, layerKey]);
-
-    return React.useMemo(() => Object.entries(cards).map(([compId, payload]) => ({compId, ...payload})).sort((a, b) => String(a.compId).localeCompare(String(b.compId))), [cards]);
-}
-
-// collect water-sensor device cards for a system
-function useWaterCompositeCards(systemKeyInput) {
-    const [cards, setCards] = React.useState({});
-    const sysKey = String(systemKeyInput || "").toUpperCase();
-
-    const isMine = React.useCallback((compId, data) => {
-        const cid = String(compId || "").trim().toUpperCase();
-        if (cid) {
-            if (!cid.startsWith(`${sysKey}-`)) return false;
-            if (!isWaterDevice(cid)) return false;
-            return true;
-        }
-        const sys = String(data?.system || data?.systemId || "").trim().toUpperCase();
-        const dev = String(data?.deviceId || data?.device || data?.devId || "").trim().toUpperCase();
-        if (sysKey && sys && sys !== sysKey) return false;
-        return !!sys && dev.startsWith("T");
-    }, [sysKey]);
-
-    const upsert = React.useCallback((compId, sensors, ts) => {
-        setCards(prev => {
-            const next = {...prev};
-            const cur = next[compId] || {sensors: {}, ts: 0};
-            const normalized = normalizeSensors(sensors);
-            for (const [k, obj] of Object.entries(normalized)) {
-                cur.sensors[k] = {value: obj.value, unit: obj.unit};
-            }
-            cur.ts = Math.max(cur.ts || 0, ts || Date.now());
-            next[compId] = cur;
-            return next;
-        });
-    }, []);
-
-    const topics = React.useMemo(() => ["/topic/growSensors", "/topic/waterTank"], []);
-    useStomp(topics, (topic, data) => {
-        if (!data) return;
-        let compId = data.compositeId || data.composite_id || data.cid;
-        if (!compId) {
-            const sys = data.system || data.systemId;
-            const lay = data.layer || data.layerId;
-            const dev = data.deviceId || data.device || data.devId;
-            if (sys && lay && dev) compId = `${sys}-${lay}-${dev}`;
-        }
-        if (!compId) return;
-        if (!isMine(compId, data)) return;
-        const sensors = data.sensors || data.values || data.env || data.water || data.payload || data.readings || [];
-        upsert(compId, sensors, data.timestamp || data.ts);
-    });
-
-    React.useEffect(() => { setCards({}); }, [sysKey]);
-
-    return React.useMemo(() => Object.entries(cards).map(([compId, payload]) => ({compId, ...payload})).sort((a,b) => String(a.compId).localeCompare(String(b.compId))), [cards]);
-}
-
-function LayerCard({layer, systemId}) {
-    // build device cards for this system/layer
-    const deviceCards = useLayerCompositeCards(systemId, layer.id).filter(card => !isWaterDevice(card.compId));
-    const agg = React.useMemo(() => aggregateFromCards(deviceCards), [deviceCards]);
-
-    return (
-        <div className={`${styles.card} ${styles.layer}`}>
-            <div className={styles.headerRow}>
-                <h4>
-                    {layer.id} <span className={`${styles.dot} ${styles[layer.health]}`}/>
-                </h4>
-            </div>
-
-            {/* always-visible summary as chips */}
-            <div className={styles.stats}>
-                {agg.counts.light > 0 && (
-                    <Stat
-                        label={`Light (${agg.counts.light} sensors)`}
-                        value={`${fmt(agg.avg.light)} lux`}
-                        range={idealRangeConfig.lux?.idealRange}
-                    />
-                )}
-                {agg.counts.temperature > 0 && (
-                    <Stat
-                        label={`Temp (${agg.counts.temperature} sensors)`}
-                        value={`${fmt(agg.avg.temperature)} °C`}
-                        range={idealRangeConfig.temperature?.idealRange}
-                    />
-                )}
-                {agg.counts.humidity > 0 && (
-                    <Stat
-                        label={`Humidity (${agg.counts.humidity} sensors)`}
-                        value={`${fmt(agg.avg.humidity)} %`}
-                        range={idealRangeConfig.humidity?.idealRange}
-                    />
-                )}
-                {agg.counts.pH > 0 && (
-                    <Stat
-                        label={`pH (${agg.counts.pH} sensors)`}
-                        value={`${fmt(agg.avg.pH)}`}
-                        range={idealRangeConfig.ph?.idealRange}
-                    />
-                )}
-                {agg.counts.co2 > 0 && (
-                    <Stat
-                        label={`CO₂ (${agg.counts.co2} sensors)`}
-                        value={`${fmt(agg.avg.co2, 0)} ppm`}
-                        // range نداریم، می‌تونی اگر داشتی بدی
-                    />
-                )}
-            </div>
-
-
-            <div className={styles.details}>
-                <div className={styles.devCards}>
-                    {deviceCards.length ? (
-                        deviceCards.map((card) => (
-                            <DeviceCard
-                                key={card.compId}
-                                compositeId={card.compId}
-                                sensors={Object.entries(card.sensors).map(([k, v]) => ({
-                                    sensorType: sensorLabel(k),
-                                    value: fmt(v?.value),
-                                    unit: v?.unit || "",
-                                }))}
-                            />
-                        ))
-                    ) : (
-                        <div className={styles.muted}>No device cards</div>
-                    )}
-                </div>
-            </div>
-        </div>
-    );
-}
+import Stat from "./Stat.jsx";
+import LayerCard from "./LayerCard.jsx";
+import useWaterCompositeCards from "./useWaterCompositeCards.js";
+import { fmt, localDateTime, normLayerId, getMetric, getCount, deriveHealth, sensorLabel } from "../utils";
 
 export default function DashboardV2() {
     const live = useLiveNow();
@@ -410,7 +55,6 @@ export default function DashboardV2() {
                 <div className={styles.stats} style={{marginBottom: 8}}>
                     {active.healthy != null && active.total != null && (
                         <Stat label="Healthy sensors / total" value={`${active.healthy} / ${active.total}`}/>)}
-                    {/*<Stat label="Layers" value={active.layers.length}/>*/}
                 </div>
                 <div className={styles.row}>
                     <div className={styles.col6}>
@@ -476,3 +120,18 @@ export default function DashboardV2() {
         </div>
     );
 }
+
+const WATER_STATS = [
+    {label: "pH", key: "pH", alt: "ph", precision: 1, rangeKey: "ph"},
+    {label: "DO", key: "dissolvedOxygen", precision: 1, rangeKey: "dissolvedOxygen"},
+    {label: "EC", key: "dissolvedEC", precision: 2, rangeKey: "ec"},
+    {label: "TDS", key: "dissolvedTDS", precision: 0, rangeKey: "tds"},
+    {label: "Temp", key: "dissolvedTemp", precision: 1, rangeKey: "temperature"},
+];
+
+const ENV_STATS = [
+    {label: "Light", key: "light", precision: 1, rangeKey: "lux"},
+    {label: "Temp", key: "temperature", precision: 1, rangeKey: "temperature"},
+    {label: "Humidity", key: "humidity", precision: 0, rangeKey: "humidity"},
+    {label: "CO₂", key: "co2", precision: 0},
+];

--- a/src/pages/Dashboard/components/LayerCard.jsx
+++ b/src/pages/Dashboard/components/LayerCard.jsx
@@ -1,0 +1,81 @@
+import React, {useMemo} from "react";
+import DeviceCard from "./DeviceCard.jsx";
+import Stat from "./Stat.jsx";
+import useLayerCompositeCards from "./useLayerCompositeCards.js";
+import idealRangeConfig from "../../../idealRangeConfig.js";
+import { fmt, aggregateFromCards, sensorLabel, isWaterDevice } from "../utils";
+import styles from "./LayerCard.module.css";
+
+function LayerCard({layer, systemId}) {
+  const deviceCards = useLayerCompositeCards(systemId, layer.id).filter(card => !isWaterDevice(card.compId));
+  const agg = useMemo(() => aggregateFromCards(deviceCards), [deviceCards]);
+
+  return (
+    <div className={`${styles.card} ${styles.layer}`}>
+      <div className={styles.headerRow}>
+        <h4>
+          {layer.id} <span className={`${styles.dot} ${styles[layer.health]}`}/>
+        </h4>
+      </div>
+
+      <div className={styles.stats}>
+        {agg.counts.light > 0 && (
+          <Stat
+            label={`Light (${agg.counts.light} sensors)`}
+            value={`${fmt(agg.avg.light)} lux`}
+            range={idealRangeConfig.lux?.idealRange}
+          />
+        )}
+        {agg.counts.temperature > 0 && (
+          <Stat
+            label={`Temp (${agg.counts.temperature} sensors)`}
+            value={`${fmt(agg.avg.temperature)} °C`}
+            range={idealRangeConfig.temperature?.idealRange}
+          />
+        )}
+        {agg.counts.humidity > 0 && (
+          <Stat
+            label={`Humidity (${agg.counts.humidity} sensors)`}
+            value={`${fmt(agg.avg.humidity)} %`}
+            range={idealRangeConfig.humidity?.idealRange}
+          />
+        )}
+        {agg.counts.pH > 0 && (
+          <Stat
+            label={`pH (${agg.counts.pH} sensors)`}
+            value={`${fmt(agg.avg.pH)}`}
+            range={idealRangeConfig.ph?.idealRange}
+          />
+        )}
+        {agg.counts.co2 > 0 && (
+          <Stat
+            label={`CO₂ (${agg.counts.co2} sensors)`}
+            value={`${fmt(agg.avg.co2, 0)} ppm`}
+          />
+        )}
+      </div>
+
+      <div className={styles.details}>
+        <div className={styles.devCards}>
+          {deviceCards.length ? (
+            deviceCards.map((card) => (
+              <DeviceCard
+                key={card.compId}
+                compositeId={card.compId}
+                sensors={Object.entries(card.sensors).map(([k, v]) => ({
+                  sensorType: sensorLabel(k),
+                  value: fmt(v?.value),
+                  unit: v?.unit || "",
+                }))}
+              />
+            ))
+          ) : (
+            <div className={styles.muted}>No device cards</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default React.memo(LayerCard);

--- a/src/pages/Dashboard/components/LayerCard.module.css
+++ b/src/pages/Dashboard/components/LayerCard.module.css
@@ -1,0 +1,61 @@
+.card {
+    background: #fff;
+    border: 0.0625rem solid #e5e7eb;
+    border-radius: 0.75rem;
+    padding: 0.875rem;
+    margin-bottom: 1rem;
+}
+
+.layer {
+    cursor: pointer;
+    transition: transform .15s ease;
+    position: relative;
+    border-left: 0.125rem solid #90c398;
+    padding-top: 0rem;
+}
+
+.layer:hover {
+    transform: translateY(-0.125rem);
+}
+
+.headerRow { display:flex; justify-content: space-between; align-items:center; cursor:pointer; }
+
+.dot {
+    width: 0.5rem;
+    height: 0.5rem;
+    border-radius: 6.1875rem;
+    display: inline-block;
+}
+
+.ok { background: #10b981; }
+.warn { background: #f59e0b; }
+.down { background: #ef4444; }
+
+.stats {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-top: 0.5rem;
+}
+
+.details {
+    margin-top: 0.5rem;
+    font-size: .9rem;
+    color: #374151;
+    border-top: 0.0625rem dashed #e5e7eb;
+    padding-top: 0.5rem;
+}
+
+.devCards {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1rem;
+    justify-items: stretch;
+    padding: 0 0.5rem;
+    box-sizing: border-box;
+}
+
+.muted {
+    color: #6b7280;
+    font-size: .9rem;
+}

--- a/src/pages/Dashboard/components/Stat.jsx
+++ b/src/pages/Dashboard/components/Stat.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import clsx from "clsx";
+import styles from "./Stat.module.css";
+
+function Stat({label, value, range}) {
+  const numeric = typeof value === "number" ? value : parseFloat(String(value).replace(",", "."));
+  let state = null;
+  if (range && typeof numeric === "number" && !Number.isNaN(numeric)) {
+    const {min, max} = range;
+    if (typeof min === "number" && typeof max === "number") {
+      const threshold = (max - min) * 0.1;
+      if (numeric < min || numeric > max) state = "danger";
+      else if (numeric < min + threshold || numeric > max - threshold) state = "warn";
+      else state = "ok";
+    }
+  }
+  return (
+    <div
+      className={clsx(
+        styles.stat,
+        state === "ok" && styles.statOk,
+        state === "warn" && styles.statWarn,
+        state === "danger" && styles.statDanger
+      )}
+    >
+      <strong>{value}</strong>
+      <span className={styles.muted}>{label}</span>
+    </div>
+  );
+}
+
+export default React.memo(Stat);

--- a/src/pages/Dashboard/components/Stat.module.css
+++ b/src/pages/Dashboard/components/Stat.module.css
@@ -1,0 +1,26 @@
+.stat {
+    background: #f3f4f6;
+    border-radius: 0.5rem;
+    padding: 0.375rem 0.625rem;
+    font-size: .92rem;
+}
+
+.statOk {
+    background: linear-gradient(180deg, #8deaa3 0%, #a7e6b2 100%);
+    color: #000;
+}
+
+.statWarn {
+    background: #fff3cd;
+    color: #000;
+}
+
+.statDanger {
+    background: #f8d7da;
+    color: #000;
+}
+
+.muted {
+    color: #6b7280;
+    font-size: .9rem;
+}

--- a/src/pages/Dashboard/components/useLayerCompositeCards.js
+++ b/src/pages/Dashboard/components/useLayerCompositeCards.js
@@ -1,0 +1,59 @@
+import React from "react";
+import { useStomp } from "../../../hooks/useStomp";
+import { normalizeSensors } from "../utils";
+
+export default function useLayerCompositeCards(systemKeyInput, layerId) {
+  const [cards, setCards] = React.useState({});
+  const layerKey = String(layerId || "").toUpperCase();
+  const sysKey = String(systemKeyInput || "").toUpperCase();
+
+  const isMine = React.useCallback((compId, data) => {
+    const cid = String(compId || "").trim().toUpperCase();
+    if (cid) {
+      if (!cid.startsWith(`${sysKey}-`)) return false;
+      if (!cid.includes(`-${layerKey}-`)) return false;
+      return true;
+    }
+    const sys = String(data?.system || data?.systemId || "").trim().toUpperCase();
+    const lay = String(data?.layer || data?.layerId || "").trim().toUpperCase();
+    if (sysKey && sys && sys !== sysKey) return false;
+    if (layerKey && lay && lay !== layerKey) return false;
+    return !!sys && !!lay;
+  }, [sysKey, layerKey]);
+
+  const upsert = React.useCallback((compId, sensors, ts) => {
+    setCards(prev => {
+      const next = {...prev};
+      const cur = next[compId] || {sensors: {}, ts: 0};
+      const normalized = normalizeSensors(sensors);
+      for (const [k, obj] of Object.entries(normalized)) {
+        cur.sensors[k] = {value: obj.value, unit: obj.unit};
+      }
+      cur.ts = Math.max(cur.ts || 0, ts || Date.now());
+      next[compId] = cur;
+      return next;
+    });
+  }, []);
+
+  const topics = React.useMemo(() => ["/topic/growSensors", "/topic/waterTank"], []);
+  useStomp(topics, (topic, data) => {
+    if (!data) return;
+    let compId = data.compositeId || data.composite_id || data.cid;
+    if (!compId) {
+      const sys = data.system || data.systemId;
+      const lay = data.layer || data.layerId;
+      const dev = data.deviceId || data.device || data.devId;
+      if (sys && lay && dev) compId = `${sys}-${lay}-${dev}`;
+    }
+    if (!compId) return;
+    if (!isMine(compId, data)) return;
+    const sensors = data.sensors || data.values || data.env || data.water || data.payload || data.readings || [];
+    upsert(compId, sensors, data.timestamp || data.ts);
+  });
+
+  React.useEffect(() => {
+    setCards({});
+  }, [sysKey, layerKey]);
+
+  return React.useMemo(() => Object.entries(cards).map(([compId, payload]) => ({compId, ...payload})).sort((a, b) => String(a.compId).localeCompare(String(b.compId))), [cards]);
+}

--- a/src/pages/Dashboard/components/useWaterCompositeCards.js
+++ b/src/pages/Dashboard/components/useWaterCompositeCards.js
@@ -1,0 +1,55 @@
+import React from "react";
+import { useStomp } from "../../../hooks/useStomp";
+import { normalizeSensors, isWaterDevice } from "../utils";
+
+export default function useWaterCompositeCards(systemKeyInput) {
+  const [cards, setCards] = React.useState({});
+  const sysKey = String(systemKeyInput || "").toUpperCase();
+
+  const isMine = React.useCallback((compId, data) => {
+    const cid = String(compId || "").trim().toUpperCase();
+    if (cid) {
+      if (!cid.startsWith(`${sysKey}-`)) return false;
+      if (!isWaterDevice(cid)) return false;
+      return true;
+    }
+    const sys = String(data?.system || data?.systemId || "").trim().toUpperCase();
+    const dev = String(data?.deviceId || data?.device || data?.devId || "").trim().toUpperCase();
+    if (sysKey && sys && sys !== sysKey) return false;
+    return !!sys && dev.startsWith("T");
+  }, [sysKey]);
+
+  const upsert = React.useCallback((compId, sensors, ts) => {
+    setCards(prev => {
+      const next = {...prev};
+      const cur = next[compId] || {sensors: {}, ts: 0};
+      const normalized = normalizeSensors(sensors);
+      for (const [k, obj] of Object.entries(normalized)) {
+        cur.sensors[k] = {value: obj.value, unit: obj.unit};
+      }
+      cur.ts = Math.max(cur.ts || 0, ts || Date.now());
+      next[compId] = cur;
+      return next;
+    });
+  }, []);
+
+  const topics = React.useMemo(() => ["/topic/growSensors", "/topic/waterTank"], []);
+  useStomp(topics, (topic, data) => {
+    if (!data) return;
+    let compId = data.compositeId || data.composite_id || data.cid;
+    if (!compId) {
+      const sys = data.system || data.systemId;
+      const lay = data.layer || data.layerId;
+      const dev = data.deviceId || data.device || data.devId;
+      if (sys && lay && dev) compId = `${sys}-${lay}-${dev}`;
+    }
+    if (!compId) return;
+    if (!isMine(compId, data)) return;
+    const sensors = data.sensors || data.values || data.env || data.water || data.payload || data.readings || [];
+    upsert(compId, sensors, data.timestamp || data.ts);
+  });
+
+  React.useEffect(() => { setCards({}); }, [sysKey]);
+
+  return React.useMemo(() => Object.entries(cards).map(([compId, payload]) => ({compId, ...payload})).sort((a,b) => String(a.compId).localeCompare(String(b.compId))), [cards]);
+}

--- a/src/pages/Dashboard/utils/index.js
+++ b/src/pages/Dashboard/utils/index.js
@@ -1,0 +1,136 @@
+export const toNum = (v) => (v == null || v === "" ? null : Number(v));
+
+export const fmt = (v, d = 1) => (v == null || Number.isNaN(v) ? "--" : Number(v).toFixed(d));
+
+export const localDateTime = (ms) => {
+  try {
+    return ms ? new Date(ms).toLocaleString() : "--";
+  } catch {
+    return "--";
+  }
+};
+
+export const normLayerId = (l) => {
+  const raw = l?.id ?? l?.layerId ?? "";
+  if (/^L\d+$/i.test(raw)) return raw.toUpperCase();
+  const m = /^layer(\d+)$/i.exec(raw || "");
+  return m ? `L${String(m[1]).padStart(2, "0")}` : (raw || "--");
+};
+
+const fixSubs = (s) => String(s).replace(/[₀₁₂₃₄₅₆₇₈₉]/g, (d) => "0123456789"["₀₁₂₃₄₅₆₇₈₉".indexOf(d)]);
+
+export function getMetric(obj, key) {
+  if (!obj) return null;
+  const val = obj[key] ?? obj[key?.toLowerCase()] ?? obj[key?.toUpperCase()];
+  if (val == null) return null;
+  return typeof val === "object" ? toNum(val.average ?? val.avg ?? val.value) : toNum(val);
+}
+
+export function getCount(obj, key) {
+  if (!obj) return 0;
+  const v = obj[key] ?? obj[key?.toLowerCase()] ?? obj[key?.toUpperCase()];
+  if (v && typeof v === "object") {
+    const n = v.deviceCount ?? v.count ?? v.sensorCount;
+    return typeof n === "number" ? n : 0;
+  }
+  return v != null ? 1 : 0;
+}
+
+export function deriveHealth(layer) {
+  const e = layer.environment || {};
+  const present = ["light", "temperature", "humidity"].map(k => getMetric(e, k)).filter(v => v != null).length;
+  return present === 0 ? "down" : present < 3 ? "warn" : "ok";
+}
+
+export const sensorLabel = (k) => ({
+  light: "Light",
+  temperature: "Temp",
+  humidity: "Humidity",
+  pH: "pH",
+  dissolvedTemp: "Water Temp",
+  dissolvedOxygen: "DO",
+  dissolvedEC: "EC",
+  dissolvedTDS: "TDS",
+  co2: "CO₂",
+}[k] || k);
+
+export function canonKey(raw) {
+  const t = fixSubs(String(raw || "")).toLowerCase();
+  if (!t) return null;
+  if (t === "light") return "light";
+  if (t === "temperature" || t === "temp") return "temperature";
+  if (t === "humidity" || t === "hum") return "humidity";
+  if (t === "co2" || t === "co₂" || t === "co2ppm") return "co2";
+  if (t === "ph") return "pH";
+  if (t === "do" || t === "dissolvedoxygen") return "dissolvedOxygen";
+  if (t === "ec" || t === "dissolvedec") return "dissolvedEC";
+  if (t === "tds" || t === "dissolvedtds") return "dissolvedTDS";
+  if (t === "watertemp" || t === "dissolvedtemp") return "dissolvedTemp";
+  return raw;
+}
+
+export function normalizeSensors(src) {
+  const out = {};
+  if (!src) return out;
+  if (Array.isArray(src)) {
+    for (const s of src) {
+      const k = canonKey(s?.sensorType ?? s?.type ?? s?.name);
+      const val = toNum(s?.value);
+      const unit = s?.unit || s?.units || s?.u;
+      if (k && val != null) out[k] = {value: val, unit};
+    }
+    return out;
+  }
+  if (typeof src === "object") {
+    for (const [k, v] of Object.entries(src)) {
+      const key = canonKey(k);
+      if (v && typeof v === "object") {
+        const val = toNum(v.value ?? v.avg ?? v.average ?? v.v);
+        const unit = v.unit || v.u;
+        if (val != null) out[key] = {value: val, unit};
+      } else if (v != null) {
+        out[key] = {value: toNum(v)};
+      }
+    }
+  }
+  return out;
+}
+
+export function aggregateFromCards(cards) {
+  const keys = ["light", "temperature", "humidity", "pH", "co2"];
+  const sums = {}, counts = {};
+  for (const c of cards || []) {
+    const s = c?.sensors || {};
+    for (const k of keys) {
+      const v = s[k]?.value;
+      const n = v == null ? null : Number(v);
+      if (n != null && !Number.isNaN(n)) {
+        sums[k] = (sums[k] || 0) + n;
+        counts[k] = (counts[k] || 0) + 1;
+      }
+    }
+  }
+  const avg = {};
+  Object.keys(sums).forEach(k => (avg[k] = sums[k] / counts[k]));
+  return {avg, counts};
+}
+
+export function isWaterDevice(compId) {
+  const parts = String(compId || "").trim().toUpperCase().split("-");
+  return parts[2]?.startsWith("T") || false;
+}
+
+export default {
+  toNum,
+  fmt,
+  localDateTime,
+  normLayerId,
+  getMetric,
+  getCount,
+  deriveHealth,
+  sensorLabel,
+  canonKey,
+  normalizeSensors,
+  aggregateFromCards,
+  isWaterDevice,
+};

--- a/tests/isWaterDevice.test.jsx
+++ b/tests/isWaterDevice.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isWaterDevice } from '../src/pages/Dashboard/components/DashboardV2.jsx';
+import { isWaterDevice } from '../src/pages/Dashboard/utils/index.js';
 
 describe('isWaterDevice', () => {
   it('detects water device IDs', () => {


### PR DESCRIPTION
## Summary
- Extract common formatting and sensor helpers into `src/pages/Dashboard/utils`
- Break out `Stat`, `LayerCard`, and composite card hooks into dedicated component files with CSS modules
- Simplify `DashboardV2` by importing new utilities/components and memoizing heavy calculations

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b61ad8774c8328b4563e8fe01483d1