### PR TITLE
refactor: extract water device helper

### DIFF
--- a/src/pages/Dashboard/components/DashboardV2.jsx
+++ b/src/pages/Dashboard/components/DashboardV2.jsx
@@ -8,6 +8,7 @@ import Stat from "./Stat.jsx";
 import LayerCard from "./LayerCard.jsx";
 import useWaterCompositeCards from "./useWaterCompositeCards.js";
 import { fmt, localDateTime, normLayerId, getMetric, getCount, deriveHealth, sensorLabel } from "../utils";
+import { isWaterDevice } from "../utils/isWaterDevice.js";
 
 export default function DashboardV2() {
     const live = useLiveNow();
@@ -36,7 +37,7 @@ export default function DashboardV2() {
 
     const [activeId, setActiveId] = useState(null);
     const active = systems.find(s => s.id === activeId) || systems[0];
-    const waterCards = useWaterCompositeCards(active?.id);
+    const waterCards = useWaterCompositeCards(active?.id).filter(card => isWaterDevice(card.compId));
     if (!live) return <div className={styles.page}>Connecting...</div>;
     if (!systems.length) return <div className={styles.page}>No systems</div>;
 

--- a/src/pages/Dashboard/utils/index.js
+++ b/src/pages/Dashboard/utils/index.js
@@ -1,3 +1,6 @@
+import { isWaterDevice } from "./isWaterDevice.js";
+export { isWaterDevice } from "./isWaterDevice.js";
+
 export const toNum = (v) => (v == null || v === "" ? null : Number(v));
 
 export const fmt = (v, d = 1) => (v == null || Number.isNaN(v) ? "--" : Number(v).toFixed(d));
@@ -113,11 +116,6 @@ export function aggregateFromCards(cards) {
   const avg = {};
   Object.keys(sums).forEach(k => (avg[k] = sums[k] / counts[k]));
   return {avg, counts};
-}
-
-export function isWaterDevice(compId) {
-  const parts = String(compId || "").trim().toUpperCase().split("-");
-  return parts[2]?.startsWith("T") || false;
 }
 
 export default {

--- a/src/pages/Dashboard/utils/isWaterDevice.js
+++ b/src/pages/Dashboard/utils/isWaterDevice.js
@@ -1,0 +1,6 @@
+export function isWaterDevice(compId) {
+  const parts = String(compId || "").trim().toUpperCase().split("-");
+  return parts[2]?.startsWith("T") || false;
+}
+
+export default isWaterDevice;

--- a/tests/isWaterDevice.test.jsx
+++ b/tests/isWaterDevice.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isWaterDevice } from '../src/pages/Dashboard/utils/index.js';
+import { isWaterDevice } from '../src/pages/Dashboard/utils/isWaterDevice.js';
 
 describe('isWaterDevice', () => {
   it('detects water device IDs', () => {


### PR DESCRIPTION
## Summary
- move `isWaterDevice` helper to its own file
- filter water cards in `DashboardV2` using new helper
- adjust tests to import the helper from its new location

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b62265e2488328b4be74bf2a35aa88