### PR TITLE
Format stats with label and sensor count

### DIFF
--- a/src/pages/Dashboard/components/DashboardV2.jsx
+++ b/src/pages/Dashboard/components/DashboardV2.jsx
@@ -70,7 +70,7 @@ export default function DashboardV2() {
                                     );
                                     const range = idealRangeConfig[rangeKey]?.idealRange;
                                     return (
-                                        <Stat key={key} label={`${label} (${count} sensors)`} value={value} range={range}/>
+                                        <Stat key={key} label={`${label}=`} value={`${value} (${count} sensors)`} range={range}/>
                                     );
                                 })}
                             </div>
@@ -104,8 +104,8 @@ export default function DashboardV2() {
                             {ENV_STATS.map(({label, key, precision, rangeKey}) => (
                                 <Stat
                                     key={key}
-                                    label={`${label} (${getCount(active.env, key)} sensors)`}
-                                    value={fmt(getMetric(active.env, key), precision)}
+                                    label={`${label}=`}
+                                    value={`${fmt(getMetric(active.env, key), precision)} (${getCount(active.env, key)} sensors)`}
                                     range={idealRangeConfig[rangeKey]?.idealRange}
                                 />
                             ))}

--- a/src/pages/Dashboard/components/LayerCard.jsx
+++ b/src/pages/Dashboard/components/LayerCard.jsx
@@ -21,36 +21,36 @@ function LayerCard({layer, systemId}) {
       <div className={styles.stats}>
         {agg.counts.light > 0 && (
           <Stat
-            label={`Light (${agg.counts.light} sensors)`}
-            value={`${fmt(agg.avg.light)} lux`}
+            label="Light="
+            value={`${fmt(agg.avg.light)} lux (${agg.counts.light} sensors)`}
             range={idealRangeConfig.lux?.idealRange}
           />
         )}
         {agg.counts.temperature > 0 && (
           <Stat
-            label={`Temp (${agg.counts.temperature} sensors)`}
-            value={`${fmt(agg.avg.temperature)} °C`}
+            label="Temp="
+            value={`${fmt(agg.avg.temperature)} °C (${agg.counts.temperature} sensors)`}
             range={idealRangeConfig.temperature?.idealRange}
           />
         )}
         {agg.counts.humidity > 0 && (
           <Stat
-            label={`Humidity (${agg.counts.humidity} sensors)`}
-            value={`${fmt(agg.avg.humidity)} %`}
+            label="Humidity="
+            value={`${fmt(agg.avg.humidity)} % (${agg.counts.humidity} sensors)`}
             range={idealRangeConfig.humidity?.idealRange}
           />
         )}
         {agg.counts.pH > 0 && (
           <Stat
-            label={`pH (${agg.counts.pH} sensors)`}
-            value={`${fmt(agg.avg.pH)}`}
+            label="pH="
+            value={`${fmt(agg.avg.pH)} (${agg.counts.pH} sensors)`}
             range={idealRangeConfig.ph?.idealRange}
           />
         )}
         {agg.counts.co2 > 0 && (
           <Stat
-            label={`CO₂ (${agg.counts.co2} sensors)`}
-            value={`${fmt(agg.avg.co2, 0)} ppm`}
+            label="CO₂="
+            value={`${fmt(agg.avg.co2, 0)} ppm (${agg.counts.co2} sensors)`}
           />
         )}
       </div>

--- a/src/pages/Dashboard/components/Stat.jsx
+++ b/src/pages/Dashboard/components/Stat.jsx
@@ -23,8 +23,8 @@ function Stat({label, value, range}) {
         state === "danger" && styles.statDanger
       )}
     >
+      <span className={styles.muted}>{label}</span>{" "}
       <strong>{value}</strong>
-      <span className={styles.muted}>{label}</span>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Show sensor labels before values with "=" and sensor counts in dashboard stats
- Apply new formatting to layer and water/environment cards
- Adjust Stat component to render label then value

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b70395bb50832891ed5adb9455174b