### PR TITLE
Add notes page for daily entries with sidebar link

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import Reports from './pages/Reports';
 import Settings from './pages/Settings';
 import UserInfo from './pages/UserInfo';
 import Documentation from './pages/Documentation';
+import Note from './pages/Note';
 import Device from './pages/filters/Device';
 import Layer from './pages/filters/Layer';
 import System from './pages/filters/System';
@@ -22,6 +23,7 @@ function App() {
                     <Route index element={<Dashboard />} />
                     <Route path="live" element={<Live />} />
                     <Route path="reports" element={<Reports />} />
+                    <Route path="note" element={<Note />} />
                     <Route path="settings" element={<Settings />} />
                     <Route path="user" element={<UserInfo />} />
                     <Route path="docs" element={<Documentation />} />

--- a/src/pages/Note/index.jsx
+++ b/src/pages/Note/index.jsx
@@ -1,0 +1,76 @@
+import React, { useEffect, useState } from 'react';
+
+function Note() {
+    const [title, setTitle] = useState('');
+    const [content, setContent] = useState('');
+    const [notes, setNotes] = useState([]);
+
+    useEffect(() => {
+        (async () => {
+            try {
+                const res = await fetch('/api/notes');
+                if (res.ok) {
+                    const data = await res.json();
+                    setNotes(Array.isArray(data) ? data : []);
+                }
+            } catch (e) {
+                console.error(e);
+            }
+        })();
+    }, []);
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        const newNote = { title, content, date: new Date().toISOString() };
+        try {
+            const res = await fetch('/api/notes', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(newNote)
+            });
+            if (res.ok) {
+                const saved = await res.json().catch(() => newNote);
+                setNotes(prev => [saved, ...prev]);
+                setTitle('');
+                setContent('');
+            }
+        } catch (err) {
+            console.error(err);
+        }
+    };
+
+    return (
+        <div style={{ padding: '1rem' }}>
+            <h2>Daily Notes</h2>
+            <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', maxWidth: '400px' }}>
+                <input
+                    type="text"
+                    placeholder="Title"
+                    value={title}
+                    onChange={e => setTitle(e.target.value)}
+                    required
+                />
+                <textarea
+                    placeholder="Write your note..."
+                    value={content}
+                    onChange={e => setContent(e.target.value)}
+                    rows={4}
+                    required
+                />
+                <button type="submit">Save</button>
+            </form>
+
+            <div style={{ marginTop: '1rem' }}>
+                {notes.map((note, idx) => (
+                    <div key={note.id ?? idx} style={{ border: '1px solid #ccc', padding: '0.5rem', marginBottom: '0.5rem' }}>
+                        <strong>{note.title}</strong>
+                        <p>{note.content}</p>
+                        <small>{new Date(note.date).toLocaleString()}</small>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}
+
+export default Note;

--- a/src/pages/common/Sidebar/index.jsx
+++ b/src/pages/common/Sidebar/index.jsx
@@ -79,6 +79,10 @@ export default function Sidebar() {
                     <span className={styles.icon}>📈</span>
                     {!collapsed && <span className={styles.text}>Reports</span>}
                 </NavLink>
+                <NavLink to="/note" className={linkClass}>
+                    <span className={styles.icon}>📝</span>
+                    {!collapsed && <span className={styles.text}>Note</span>}
+                </NavLink>
                 <NavLink to="/settings" className={linkClass}>
                     <span className={styles.icon}>⚙️</span>
                     {!collapsed && <span className={styles.text}>Settings</span>}

--- a/tests/Sidebar.test.jsx
+++ b/tests/Sidebar.test.jsx
@@ -29,3 +29,17 @@ test('renders Live link', () => {
     expect(liveLink).toHaveAttribute('href', '/live');
 });
 
+test('renders Note link', () => {
+    render(
+        <FiltersProvider>
+            <MemoryRouter>
+                <Sidebar />
+            </MemoryRouter>
+        </FiltersProvider>
+    );
+
+    const noteLink = screen.getByRole('link', { name: /note/i });
+    expect(noteLink).toBeInTheDocument();
+    expect(noteLink).toHaveAttribute('href', '/note');
+});
+


### PR DESCRIPTION
## Summary
- Add `Note` page to record daily notes and send them to `/api/notes`
- Wire up routing and sidebar link to access the new Note page
- Extend sidebar tests to cover new Note link

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b83732a1c08328869198378febe6a3