### PR TITLE
fix: send note requests to configured API base

### DIFF
--- a/src/pages/Note/index.jsx
+++ b/src/pages/Note/index.jsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
+const API_BASE = import.meta.env.VITE_API_BASE ?? 'http://localhost:8080';
+
 function Note() {
     const [title, setTitle] = useState('');
     const [content, setContent] = useState('');
@@ -8,7 +10,7 @@ function Note() {
     useEffect(() => {
         (async () => {
             try {
-                const res = await fetch('/api/notes');
+                const res = await fetch(`${API_BASE}/api/notes`);
                 if (res.ok) {
                     const data = await res.json();
                     setNotes(Array.isArray(data) ? data : []);
@@ -23,7 +25,7 @@ function Note() {
         e.preventDefault();
         const newNote = { title, content, date: new Date().toISOString() };
         try {
-            const res = await fetch('/api/notes', {
+            const res = await fetch(`${API_BASE}/api/notes`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(newNote)


### PR DESCRIPTION
## Summary
- read API base URL from `VITE_API_BASE` with default `http://localhost:8080`
- post note data to `${API_BASE}/api/notes`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8461c7b148328842129b08d944f54