### PR TITLE
test: add sensor config API mocks and page tests

### DIFF
--- a/tests/DashboardFilter.test.jsx
+++ b/tests/DashboardFilter.test.jsx
@@ -2,6 +2,9 @@ import React, { useState } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import FilterBar from '../src/pages/common/FilterBar';
+import { SensorConfigProvider } from '../src/context/SensorConfigContext.jsx';
+import { mockSensorConfigApi } from './mocks/sensorConfigApi.js';
+import { vi } from 'vitest';
 
 const systems = [
   {
@@ -46,8 +49,20 @@ function TestDashboard() {
   );
 }
 
+beforeEach(() => {
+  mockSensorConfigApi();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 test('filters layers and systems based on selections', () => {
-  render(<TestDashboard />);
+  render(
+    <SensorConfigProvider>
+      <TestDashboard />
+    </SensorConfigProvider>
+  );
   expect(screen.getByTestId('layer-S01-L01')).toBeInTheDocument();
   fireEvent.click(screen.getByLabelText('S01-L01'));
   expect(screen.queryByTestId('layer-S01-L01')).not.toBeInTheDocument();

--- a/tests/DeviceTable.test.jsx
+++ b/tests/DeviceTable.test.jsx
@@ -4,6 +4,8 @@ import '@testing-library/jest-dom';
 import DeviceTable from '../src/pages/Live/components/DeviceTable';
 import styles from '../src/pages/Live/components/DeviceTable/DeviceTable.module.css';
 import { SensorConfigProvider } from '../src/context/SensorConfigContext.jsx';
+import { mockSensorConfigApi } from './mocks/sensorConfigApi.js';
+import { vi } from 'vitest';
 
 const devices = {
   dev1: {
@@ -28,8 +30,16 @@ const devices = {
 };
 
 const renderWithProvider = (ui) => render(
-  <SensorConfigProvider initialConfigs={{}}>{ui}</SensorConfigProvider>
+  <SensorConfigProvider>{ui}</SensorConfigProvider>
 );
+
+beforeEach(() => {
+  mockSensorConfigApi();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 test('renders sensor model and measurement type headers', () => {
   renderWithProvider(<DeviceTable devices={devices} />);

--- a/tests/DeviceTableWaterTank.test.jsx
+++ b/tests/DeviceTableWaterTank.test.jsx
@@ -3,6 +3,8 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import DeviceTable from '../src/pages/Live/components/DeviceTable';
 import { SensorConfigProvider } from '../src/context/SensorConfigContext.jsx';
+import { mockSensorConfigApi } from './mocks/sensorConfigApi.js';
+import { vi } from 'vitest';
 
 const devices = {
   tank1: {
@@ -17,8 +19,16 @@ const devices = {
 };
 
 const renderWithProvider = (ui) => render(
-  <SensorConfigProvider initialConfigs={{}}>{ui}</SensorConfigProvider>
+  <SensorConfigProvider>{ui}</SensorConfigProvider>
 );
+
+beforeEach(() => {
+  mockSensorConfigApi();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 test('renders sensor models from sensors array', () => {
   renderWithProvider(<DeviceTable devices={devices} />);

--- a/tests/SensorConfigPage.test.jsx
+++ b/tests/SensorConfigPage.test.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import SensorConfig from '../src/pages/SensorConfig';
+import { SensorConfigProvider } from '../src/context/SensorConfigContext.jsx';
+import { mockSensorConfigApi } from './mocks/sensorConfigApi.js';
+import { vi } from 'vitest';
+
+const renderPage = () => {
+  mockSensorConfigApi();
+  return render(
+    <SensorConfigProvider>
+      <SensorConfig />
+    </SensorConfigProvider>
+  );
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test('creates a new sensor config', async () => {
+  renderPage();
+  await screen.findByText('temperature');
+  fireEvent.change(screen.getByLabelText('Key:'), { target: { value: 'humidity' } });
+  fireEvent.change(screen.getByLabelText('Min:'), { target: { value: '40' } });
+  fireEvent.change(screen.getByLabelText('Max:'), { target: { value: '60' } });
+  fireEvent.change(screen.getByLabelText('Description:'), { target: { value: 'Humidity sensor' } });
+  fireEvent.click(screen.getByText('Create'));
+  await screen.findByText('humidity');
+});
+
+test('updates an existing sensor config', async () => {
+  renderPage();
+  const editBtn = await screen.findByRole('button', { name: 'Edit' });
+  fireEvent.click(editBtn);
+  const minInput = screen.getByLabelText('Min:');
+  fireEvent.change(minInput, { target: { value: '15' } });
+  fireEvent.click(screen.getByText('Update'));
+  await waitFor(() => expect(screen.getByText('15')).toBeInTheDocument());
+});
+
+test('deletes an existing sensor config', async () => {
+  renderPage();
+  const delBtn = await screen.findByRole('button', { name: 'Delete' });
+  fireEvent.click(delBtn);
+  await waitFor(() => expect(screen.queryByText('temperature')).not.toBeInTheDocument());
+});

--- a/tests/SpectrumBarChart.test.jsx
+++ b/tests/SpectrumBarChart.test.jsx
@@ -4,6 +4,7 @@ import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 import SpectrumBarChart from '../src/pages/Live/components/SpectrumBarChart';
 import { SensorConfigProvider } from '../src/context/SensorConfigContext.jsx';
+import { mockSensorConfigApi } from './mocks/sensorConfigApi.js';
 
 
 Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
@@ -24,6 +25,14 @@ vi.mock('recharts', async () => {
     };
 });
 
+beforeEach(() => {
+    mockSensorConfigApi();
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
 test('renders spectrum bar chart', () => {
     const data = {
         F1: 1, F2: 2, F3: 3, F4: 4,
@@ -32,7 +41,7 @@ test('renders spectrum bar chart', () => {
     };
 
     const { container } = render(
-        <SensorConfigProvider initialConfigs={{}}>
+        <SensorConfigProvider>
             <div style={{ width: 800, height: 400 }}>
                 <SpectrumBarChart sensorData={data} />
             </div>
@@ -51,7 +60,7 @@ test('renders spectrum bar chart for as7343 data', () => {
     };
 
     const { container } = render(
-        <SensorConfigProvider initialConfigs={{}}>
+        <SensorConfigProvider>
             <div style={{ width: 800, height: 400 }}>
                 <SpectrumBarChart sensorData={data} />
             </div>

--- a/tests/data/sensorConfigs.json
+++ b/tests/data/sensorConfigs.json
@@ -1,0 +1,6 @@
+{
+  "temperature": {
+    "idealRange": { "min": 20, "max": 30 },
+    "description": "Temperature sensor"
+  }
+}

--- a/tests/mocks/sensorConfigApi.js
+++ b/tests/mocks/sensorConfigApi.js
@@ -1,0 +1,32 @@
+import configsData from '../data/sensorConfigs.json';
+import { vi } from 'vitest';
+
+export function mockSensorConfigApi() {
+  let configs = { ...configsData };
+  global.fetch = vi.fn(async (url, options = {}) => {
+    const method = (options.method || 'GET').toUpperCase();
+    if (url === '/api/sensor-configs' && method === 'GET') {
+      return { ok: true, json: async () => configs };
+    }
+    if (url === '/api/sensor-configs' && method === 'POST') {
+      const body = JSON.parse(options.body);
+      const { key, ...cfg } = body;
+      configs[key] = cfg;
+      return { ok: true, json: async () => cfg };
+    }
+    const match = url.match(/^\/api\/sensor-configs\/([^/]+)$/);
+    if (match && method === 'PUT') {
+      const key = decodeURIComponent(match[1]);
+      const cfg = JSON.parse(options.body);
+      configs[key] = cfg;
+      return { ok: true, json: async () => cfg };
+    }
+    if (match && method === 'DELETE') {
+      const key = decodeURIComponent(match[1]);
+      delete configs[key];
+      return { ok: true, json: async () => ({}) };
+    }
+    return { ok: false, json: async () => ({}) };
+  });
+  return { getConfigs: () => configs };
+}


### PR DESCRIPTION
## Summary
- add mock sensor-config API with sample data for tests
- wrap component tests in SensorConfigProvider
- add create/update/delete tests for Sensor Config page

## Testing
- `npm test`
- `npm run lint` *(fails: useSensorConfig is not defined in NotesBlock.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b85f7c6768832894c6f4030e46fe2d