### PR TITLE
Handle missing metrics in system and layer cards

### DIFF
--- a/src/pages/SystemAndLayerCards/index.jsx
+++ b/src/pages/SystemAndLayerCards/index.jsx
@@ -74,8 +74,8 @@ export function SystemOverviewCard({
                                        sensorsHealthy,
                                        sensorsTotal,
                                        lastUpdateMs,
-                                       layers,
-                                       metrics,
+                                       layers = [],
+                                       metrics = {},
                                        onClick,
                                    }) {
     return (
@@ -129,7 +129,7 @@ export function SystemOverviewCard({
 }
 
 /* ========== Layer Panel ========== */
-export function LayerPanel({id, health, metrics, water = {}, actuators = {}, children}) {
+export function LayerPanel({id, health, metrics = {}, water = {}, actuators = {}, children}) {
     return (
         <div className={cx("card", "layer-card")}> 
             <div className={cx("layer-head")}>


### PR DESCRIPTION
## Summary
- avoid `undefined` errors for CO2 by defaulting `metrics` and `layers`
- default `metrics` in layer panel to prevent runtime property errors

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: 'sensorConfigs' is assigned a value but never used... `react-hooks/rules-of-hooks`)*

------
https://chatgpt.com/codex/tasks/task_e_68b87680290883289aa5689ebf48c555