### PR TITLE
Use SensorConfig page for sensor configuration route

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,7 +5,7 @@ import Dashboard from './pages/Dashboard';
 import Live from './pages/Live';
 import Reports from './pages/Reports';
 import UserInfo from './pages/UserInfo';
-import Documentation from './pages/Documentation';
+import SensorConfig from './pages/SensorConfig';
 import Note from './pages/Note';
 import Device from './pages/filters/Device';
 import Layer from './pages/filters/Layer';
@@ -24,7 +24,7 @@ function App() {
                     <Route path="reports" element={<Reports />} />
                     <Route path="note" element={<Note />} />
                     <Route path="user" element={<UserInfo />} />
-                    <Route path="sensor-config" element={<Documentation />} />
+                    <Route path="sensor-config" element={<SensorConfig />} />
                     <Route path="filters/device" element={<Device />} />
                     <Route path="filters/layer" element={<Layer />} />
                     <Route path="filters/system" element={<System />} />


### PR DESCRIPTION
## Summary
- Import `SensorConfig` and render it for the `sensor-config` route instead of `Documentation`

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: 'sensorConfigs' unused, conditional hook usage)*

------
https://chatgpt.com/codex/tasks/task_e_68b88e307a348328b6f81585c429a8ff