### PR TITLE
refactor: remove nested sensor config provider

### DIFF
--- a/src/layouts/MainLayout.jsx
+++ b/src/layouts/MainLayout.jsx
@@ -2,19 +2,16 @@ import React from 'react';
 import { Outlet } from "react-router-dom";
 import Sidebar from "../pages/common/Sidebar";
 import { FiltersProvider } from "../context/FiltersContext";
-import { SensorConfigProvider } from "../context/SensorConfigContext.jsx";
 
 export default function MainLayout() {
     return (
         <FiltersProvider>
-            <SensorConfigProvider>
-                <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
-                    <Sidebar />
-                    <main style={{ flexGrow: 1, overflowY: "auto" }}>
-                        <Outlet />
-                    </main>
-                </div>
-            </SensorConfigProvider>
+            <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
+                <Sidebar />
+                <main style={{ flexGrow: 1, overflowY: "auto" }}>
+                    <Outlet />
+                </main>
+            </div>
         </FiltersProvider>
     );
 }


### PR DESCRIPTION
## Summary
- remove redundant SensorConfigProvider from MainLayout to avoid nested providers
- keep index-level SensorConfigProvider wrapping the entire app

## Testing
- `npm test`
- `npm run lint` *(fails: 2 errors, 11 warnings)*
- `npx eslint src/layouts/MainLayout.jsx src/index.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68b891611ec08328b5b66a9a580c6227