### PR TITLE
Use correct API base for sensor config requests

### DIFF
--- a/src/context/SensorConfigContext.jsx
+++ b/src/context/SensorConfigContext.jsx
@@ -2,6 +2,10 @@ import React, { createContext, useContext, useEffect, useState } from 'react';
 
 const Ctx = createContext(null);
 
+// Base URL for REST API requests. Falls back to the public API if the
+// environment variable is not provided.
+const API_BASE = import.meta.env.VITE_API_BASE ?? 'https://api.hydroleaf.se';
+
 export function SensorConfigProvider({ children }) {
     const [configs, setConfigs] = useState({});
     const [error, setError] = useState('');
@@ -15,7 +19,7 @@ export function SensorConfigProvider({ children }) {
     async function loadConfigs() {
         try {
             setError('');
-            const res = await fetch('/api/sensor-config');
+            const res = await fetch(`${API_BASE}/api/sensor-config`);
             if (!res.ok) throw new Error(await safeError(res));
             const data = await res.json();
             const map = (Array.isArray(data) ? data : []).reduce((m, x) => (m[x.key] = x, m), {});
@@ -24,7 +28,7 @@ export function SensorConfigProvider({ children }) {
     }
 
     async function createConfig(key, payload) {
-        const res = await fetch(`/api/sensor-config/${encodeURIComponent(key)}`, {
+        const res = await fetch(`${API_BASE}/api/sensor-config/${encodeURIComponent(key)}`, {
             method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload),
         });
         if (!res.ok) throw new Error(await safeError(res));
@@ -34,7 +38,7 @@ export function SensorConfigProvider({ children }) {
     }
 
     async function updateConfig(key, payload) {
-        const res = await fetch(`/api/sensor-config/${encodeURIComponent(key)}`, {
+        const res = await fetch(`${API_BASE}/api/sensor-config/${encodeURIComponent(key)}`, {
             method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload),
         });
         if (!res.ok) throw new Error(await safeError(res));
@@ -44,7 +48,7 @@ export function SensorConfigProvider({ children }) {
     }
 
     async function deleteConfig(key) {
-        const res = await fetch(`/api/sensor-config/${encodeURIComponent(key)}`, { method: 'DELETE' });
+        const res = await fetch(`${API_BASE}/api/sensor-config/${encodeURIComponent(key)}`, { method: 'DELETE' });
         if (!res.ok) throw new Error(await safeError(res));
         setConfigs(prev => { const c = { ...prev }; delete c[key]; return c; });
     }

--- a/tests/mocks/sensorConfigApi.js
+++ b/tests/mocks/sensorConfigApi.js
@@ -16,12 +16,13 @@ export function mockSensorConfigApi() {
 
   global.fetch = vi.fn(async (url, opts = {}) => {
     const method = (opts.method || 'GET').toUpperCase();
+    const { pathname } = typeof url === 'string' ? new URL(url, 'https://api.hydroleaf.se') : url;
 
-    if (url === '/api/sensor-config' && method === 'GET') {
+    if (pathname === '/api/sensor-config' && method === 'GET') {
       return makeRes(true, 200, Object.values(db));
     }
 
-    const m = url.match(/^\/api\/sensor-config\/([^/]+)$/);
+    const m = pathname.match(/^\/api\/sensor-config\/([^/]+)$/);
     if (m) {
       const key = decodeURIComponent(m[1]);
 


### PR DESCRIPTION
## Summary
- Prefix sensor config requests with API base URL to point at api.hydroleaf.se
- Update sensor config API mock to handle absolute URLs during tests

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68b8bfd602b08328accf6f67962fafd2