### PR TITLE
refactor: adjust sensor config API

### DIFF
--- a/src/context/SensorConfigContext.jsx
+++ b/src/context/SensorConfigContext.jsx
@@ -22,35 +22,37 @@ export function SensorConfigProvider({ children }) {
             const res = await fetch(`${API_BASE}/api/sensor-config`);
             if (!res.ok) throw new Error(await safeError(res));
             const data = await res.json();
-            const map = (Array.isArray(data) ? data : []).reduce((m, x) => (m[x.key] = x, m), {});
+            const map = (Array.isArray(data) ? data : []).reduce((m, x) => (m[x.sensor_type] = x, m), {});
             setConfigs(map);
         } catch (e) { setError(e.message || 'Failed to load sensor configs'); }
     }
 
-    async function createConfig(key, payload) {
-        const res = await fetch(`${API_BASE}/api/sensor-config/${encodeURIComponent(key)}`, {
-            method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload),
+    async function createConfig(sensor_type, payload) {
+        const res = await fetch(`${API_BASE}/api/sensor-config/`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ sensor_type, ...payload }),
         });
         if (!res.ok) throw new Error(await safeError(res));
         const saved = await res.json();
-        setConfigs(prev => ({ ...prev, [saved.key]: saved }));
+        setConfigs(prev => ({ ...prev, [saved.sensor_type]: saved }));
         return saved;
     }
 
-    async function updateConfig(key, payload) {
-        const res = await fetch(`${API_BASE}/api/sensor-config/${encodeURIComponent(key)}`, {
+    async function updateConfig(sensor_type, payload) {
+        const res = await fetch(`${API_BASE}/api/sensor-config/${encodeURIComponent(sensor_type)}`, {
             method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload),
         });
         if (!res.ok) throw new Error(await safeError(res));
         const saved = await res.json();
-        setConfigs(prev => ({ ...prev, [key]: saved }));
+        setConfigs(prev => ({ ...prev, [sensor_type]: saved }));
         return saved;
     }
 
-    async function deleteConfig(key) {
-        const res = await fetch(`${API_BASE}/api/sensor-config/${encodeURIComponent(key)}`, { method: 'DELETE' });
+    async function deleteConfig(sensor_type) {
+        const res = await fetch(`${API_BASE}/api/sensor-config/${encodeURIComponent(sensor_type)}`, { method: 'DELETE' });
         if (!res.ok) throw new Error(await safeError(res));
-        setConfigs(prev => { const c = { ...prev }; delete c[key]; return c; });
+        setConfigs(prev => { const c = { ...prev }; delete c[sensor_type]; return c; });
     }
 
     return (

--- a/src/pages/SensorConfig/index.jsx
+++ b/src/pages/SensorConfig/index.jsx
@@ -5,12 +5,12 @@ export default function SensorConfigPage() {
     const { configs, error, createConfig, updateConfig, deleteConfig } = useSensorConfig();
 
     const [form, setForm] = useState({
-        key: '',
+        sensor_type: '',
         minValue: '',
         maxValue: '',
         description: '',
     });
-    const [editing, setEditing] = useState(null); // key being edited or null
+    const [editing, setEditing] = useState(null); // sensor_type being edited or null
     const [message, setMessage] = useState('');
 
     // Handle input changes
@@ -21,7 +21,7 @@ export default function SensorConfigPage() {
 
     const resetForm = () => {
         setEditing(null);
-        setForm({ key: '', minValue: '', maxValue: '', description: '' });
+        setForm({ sensor_type: '', minValue: '', maxValue: '', description: '' });
     };
 
     // Validate and submit
@@ -29,13 +29,13 @@ export default function SensorConfigPage() {
         e.preventDefault();
         setMessage('');
 
-        const key = form.key.trim();
+        const sensorType = form.sensor_type.trim();
         const minNum = Number(form.minValue);
         const maxNum = Number(form.maxValue);
         const description = form.description?.trim() || '';
 
         // Frontend validation
-        if ((!editing && !key) || form.minValue === '' || form.maxValue === '' || !Number.isFinite(minNum) || !Number.isFinite(maxNum)) {
+        if ((!editing && !sensorType) || form.minValue === '' || form.maxValue === '' || !Number.isFinite(minNum) || !Number.isFinite(maxNum)) {
             setMessage('Invalid config');
             return; // important: stop here
         }
@@ -46,7 +46,7 @@ export default function SensorConfigPage() {
             if (editing) {
                 await updateConfig(editing, payload);
             } else {
-                await createConfig(key, payload);
+                await createConfig(sensorType, payload);
             }
             setMessage('Saved');
             resetForm();
@@ -55,23 +55,23 @@ export default function SensorConfigPage() {
         }
     };
 
-    const startEdit = (key) => {
-        const cfg = configs[key] || {};
-        setEditing(key);
+    const startEdit = (sensorType) => {
+        const cfg = configs[sensorType] || {};
+        setEditing(sensorType);
         setForm({
-            key,
+            sensor_type: sensorType,
             minValue: cfg.minValue ?? '',
             maxValue: cfg.maxValue ?? '',
             description: cfg.description ?? '',
         });
     };
 
-    const handleDelete = async (key) => {
+    const handleDelete = async (sensorType) => {
         setMessage('');
         try {
-            await deleteConfig(key);
+            await deleteConfig(sensorType);
             setMessage('Deleted');
-            if (editing === key) resetForm();
+            if (editing === sensorType) resetForm();
         } catch (err) {
             setMessage(err.message || 'Failed to delete');
         }
@@ -87,10 +87,10 @@ export default function SensorConfigPage() {
             <form onSubmit={handleSubmit}>
                 <div>
                     <label>
-                        Key:
+                        Sensor Type:
                         <input
-                            name="key"
-                            value={form.key}
+                            name="sensor_type"
+                            value={form.sensor_type}
                             onChange={onChange}
                             disabled={Boolean(editing)}
                         />
@@ -143,7 +143,7 @@ export default function SensorConfigPage() {
             <table style={{ marginTop: 16, borderCollapse: 'collapse' }}>
                 <thead>
                 <tr>
-                    <th style={{ textAlign: 'left', paddingRight: 8 }}>Key</th>
+                    <th style={{ textAlign: 'left', paddingRight: 8 }}>Sensor Type</th>
                     <th style={{ textAlign: 'left', paddingRight: 8 }}>Min</th>
                     <th style={{ textAlign: 'left', paddingRight: 8 }}>Max</th>
                     <th style={{ textAlign: 'left', paddingRight: 8 }}>Description</th>
@@ -151,15 +151,15 @@ export default function SensorConfigPage() {
                 </tr>
                 </thead>
                 <tbody>
-                {Object.entries(configs).map(([key, cfg]) => (
-                    <tr key={key}>
-                        <td>{key}</td>
+                {Object.entries(configs).map(([sensorType, cfg]) => (
+                    <tr key={sensorType}>
+                        <td>{sensorType}</td>
                         <td>{cfg?.minValue}</td>
                         <td>{cfg?.maxValue}</td>
                         <td>{cfg?.description}</td>
                         <td>
-                            <button type="button" onClick={() => startEdit(key)}>Edit</button>
-                            <button type="button" onClick={() => handleDelete(key)} style={{ marginLeft: 8 }}>
+                            <button type="button" onClick={() => startEdit(sensorType)}>Edit</button>
+                            <button type="button" onClick={() => handleDelete(sensorType)} style={{ marginLeft: 8 }}>
                                 Delete
                             </button>
                         </td>

--- a/tests/SensorConfigPage.test.jsx
+++ b/tests/SensorConfigPage.test.jsx
@@ -10,7 +10,7 @@ beforeEach(() => { mockSensorConfigApi(); });
 test('create a config (assert Saved)', async () => {
   renderWithProviders(<SensorConfig />);
 
-  fireEvent.change(screen.getByLabelText(/Key:/i), { target: { value: 'humidity' } });
+  fireEvent.change(screen.getByLabelText(/Sensor Type:/i), { target: { value: 'humidity' } });
   fireEvent.change(screen.getByLabelText(/Min:/i), { target: { value: '40' } });
   fireEvent.change(screen.getByLabelText(/Max:/i), { target: { value: '60' } });
   fireEvent.click(screen.getByRole('button', { name: /create/i }));

--- a/tests/mocks/sensorConfigApi.js
+++ b/tests/mocks/sensorConfigApi.js
@@ -4,7 +4,7 @@ import { vi } from 'vitest';
 export function mockSensorConfigApi() {
   // حالت ساده: در حافظه نگه می‌داریم
   const db = {
-    temperature: { key: 'temperature', minValue: 20, maxValue: 30, description: '' },
+    temperature: { sensor_type: 'temperature', minValue: 20, maxValue: 30, description: '' },
   };
 
   const makeRes = (ok, status, body) => ({
@@ -18,25 +18,27 @@ export function mockSensorConfigApi() {
     const method = (opts.method || 'GET').toUpperCase();
     const { pathname } = typeof url === 'string' ? new URL(url, 'https://api.hydroleaf.se') : url;
 
-    if (pathname === '/api/sensor-config' && method === 'GET') {
+    if ((pathname === '/api/sensor-config' || pathname === '/api/sensor-config/') && method === 'GET') {
       return makeRes(true, 200, Object.values(db));
+    }
+
+    if ((pathname === '/api/sensor-config' || pathname === '/api/sensor-config/') && method === 'POST') {
+      const p = JSON.parse(opts.body || '{}');
+      const key = p.sensor_type;
+      if (!key) return makeRes(false, 400, 'Missing sensor_type');
+      if (db[key]) return makeRes(false, 409, 'Duplicate key');
+      db[key] = { sensor_type: key, ...p };
+      return makeRes(true, 201, db[key]);
     }
 
     const m = pathname.match(/^\/api\/sensor-config\/([^/]+)$/);
     if (m) {
       const key = decodeURIComponent(m[1]);
 
-      if (method === 'POST') {
-        if (db[key]) return makeRes(false, 409, 'Duplicate key');
-        const p = JSON.parse(opts.body || '{}');
-        db[key] = { key, ...p };
-        return makeRes(true, 201, db[key]);
-      }
-
       if (method === 'PUT') {
         if (!db[key]) return makeRes(false, 404, 'Not found');
         const p = JSON.parse(opts.body || '{}');
-        db[key] = { key, ...p };
+        db[key] = { sensor_type: key, ...p };
         return makeRes(true, 200, db[key]);
       }
 


### PR DESCRIPTION
## Summary
- update sensor config context to use sensor_type and new endpoint
- rename SensorConfig page inputs from key to sensor_type
- adjust tests and mocks for sensor_type-based configs

## Testing
- `npm test`
- `npm run lint` *(fails: 'sensorConfigs' is assigned a value but never used...)*

------
https://chatgpt.com/codex/tasks/task_e_68b94e55d50c8328b8da461c49f975bc