### PR TITLE
Refactor DeviceTable sensor config hook usage

### DIFF
--- a/src/pages/Live/components/DeviceTable/index.jsx
+++ b/src/pages/Live/components/DeviceTable/index.jsx
@@ -12,7 +12,7 @@ function getCellColor(value, range) {
 }
 
 function DeviceTable({devices = {}}) {
-    const { sensorConfigs } = useSensorConfig();
+    const { configs } = useSensorConfig();
     const compositeIds = Object.keys(devices);
     const allSensors = compositeIds.flatMap(id => devices[id].sensors || []);
     const measurementTypes = new Set();
@@ -56,7 +56,6 @@ function DeviceTable({devices = {}}) {
         );
     }
 
-    const { configs } = useSensorConfig();
     const rows = [...measurementTypes].map(measurementType => {
         const sensorModel = measurementToSensorModel[measurementType] || '-';
         const range = configs[measurementType]?.idealRange;

--- a/tests/DeviceTable.test.jsx
+++ b/tests/DeviceTable.test.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import DeviceTable from '../src/pages/Live/components/DeviceTable';
 import styles from '../src/pages/Live/components/DeviceTable/DeviceTable.module.css';
 import { SensorConfigProvider } from '../src/context/SensorConfigContext.jsx';
+import * as SensorConfigContext from '../src/context/SensorConfigContext.jsx';
 import { mockSensorConfigApi } from './mocks/sensorConfigApi.js';
 import { vi } from 'vitest';
 
@@ -86,4 +87,12 @@ test('shows green indicator when health keys are lowercase', () => {
   const { container } = renderWithProvider(<DeviceTable devices={devicesLower} />);
   const indicator = container.querySelector(`.${styles.indicator}`);
   expect(indicator).toHaveClass(styles.on);
+});
+
+test('uses sensor config hook only once per render', async () => {
+  const spy = vi.spyOn(SensorConfigContext, 'useSensorConfig');
+  renderWithProvider(<DeviceTable devices={devices} />);
+  await waitFor(() => {
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
## Summary
- refactor DeviceTable to use a single `useSensorConfig` call
- add unit test verifying `useSensorConfig` hook is only invoked once per render

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b9822bb0c883288c68046d69d0623d