### PR TITLE
Include ideal sensor ranges in mock data

### DIFF
--- a/tests/DeviceTable.test.jsx
+++ b/tests/DeviceTable.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import DeviceTable from '../src/pages/Live/components/DeviceTable';
 import styles from '../src/pages/Live/components/DeviceTable/DeviceTable.module.css';
@@ -67,6 +67,18 @@ test('renders sensor values with correct units', () => {
   expect(screen.getByText('22.5 °C')).toBeInTheDocument();
   expect(screen.getByText('800.0 ppm')).toBeInTheDocument();
   expect(screen.getByText('6.2')).toBeInTheDocument(); // Ph has no unit
+});
+
+test('displays configured min and max values', async () => {
+  renderWithProvider(<DeviceTable devices={devices} />);
+  const tempRow = screen.getByText('Temp').closest('tr');
+  const spectralRow = screen.getByText('415nm').closest('tr');
+  await waitFor(() => {
+    expect(within(tempRow).getByText('20')).toBeInTheDocument();
+    expect(within(tempRow).getByText('30')).toBeInTheDocument();
+    expect(within(spectralRow).getByText('0')).toBeInTheDocument();
+    expect(within(spectralRow).getByText('100')).toBeInTheDocument();
+  });
 });
 
 test('applies spectral background color to 415nm row', () => {

--- a/tests/SpectrumBarChart.test.jsx
+++ b/tests/SpectrumBarChart.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 import SpectrumBarChart from '../src/pages/Live/components/SpectrumBarChart';
@@ -49,6 +49,22 @@ test('renders spectrum bar chart', () => {
     );
 
   expect(container.firstChild).toBeInTheDocument();
+});
+
+test('renders reference area when ideal range is provided', async () => {
+    const data = { F1: 50 };
+
+    const { container } = render(
+        <SensorConfigProvider>
+            <div style={{ width: 800, height: 400 }}>
+                <SpectrumBarChart sensorData={data} />
+            </div>
+        </SensorConfigProvider>
+    );
+
+    await waitFor(() => {
+        expect(container.querySelectorAll('.recharts-reference-area').length).toBe(1);
+    });
 });
 
 test('renders spectrum bar chart for as7343 data', () => {

--- a/tests/mocks/sensorConfigApi.js
+++ b/tests/mocks/sensorConfigApi.js
@@ -5,6 +5,7 @@ export function mockSensorConfigApi() {
   // حالت ساده: در حافظه نگه می‌داریم
   const db = {
     temperature: { sensorType: 'temperature', minValue: 20, maxValue: 30, description: '' },
+    '415nm': { sensorType: '415nm', minValue: 0, maxValue: 100, description: '' },
   };
 
   const makeRes = (ok, status, body) => ({
@@ -14,12 +15,20 @@ export function mockSensorConfigApi() {
     text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
   });
 
+  const withIdealRange = cfg => ({
+    ...cfg,
+    idealRange: {
+      min: cfg.minValue,
+      max: cfg.maxValue,
+    },
+  });
+
   global.fetch = vi.fn(async (url, opts = {}) => {
     const method = (opts.method || 'GET').toUpperCase();
     const { pathname } = typeof url === 'string' ? new URL(url, 'https://api.hydroleaf.se') : url;
 
     if ((pathname === '/api/sensor-config' || pathname === '/api/sensor-config/') && method === 'GET') {
-      return makeRes(true, 200, Object.values(db));
+      return makeRes(true, 200, Object.values(db).map(withIdealRange));
     }
 
     if ((pathname === '/api/sensor-config' || pathname === '/api/sensor-config/') && method === 'POST') {
@@ -28,7 +37,7 @@ export function mockSensorConfigApi() {
       if (!key) return makeRes(false, 400, 'Missing sensorType');
       if (db[key]) return makeRes(false, 409, 'Duplicate key');
       db[key] = { sensorType: key, ...rest };
-      return makeRes(true, 201, db[key]);
+      return makeRes(true, 201, withIdealRange(db[key]));
     }
 
     const m = pathname.match(/^\/api\/sensor-config\/([^/]+)$/);
@@ -39,7 +48,7 @@ export function mockSensorConfigApi() {
         if (!db[key]) return makeRes(false, 404, 'Not found');
         const { sensorType, ...rest } = JSON.parse(opts.body || '{}');
         db[key] = { sensorType: key, ...rest };
-        return makeRes(true, 200, db[key]);
+        return makeRes(true, 200, withIdealRange(db[key]));
       }
 
       if (method === 'DELETE') {


### PR DESCRIPTION
## Summary
- enrich sensor config mock with `idealRange` derived from min/max values
- verify device table shows configured ranges
- ensure spectrum chart renders reference area when ideal ranges exist

## Testing
- ⚠️ `npm test` *(command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68b984822cb48328881b8f733ee83d0d