### PR TITLE
Remove application filters from sidebar

### DIFF
--- a/src/context/SensorConfigContext.jsx
+++ b/src/context/SensorConfigContext.jsx
@@ -86,6 +86,7 @@ export function SensorConfigProvider({ children }) {
     );
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export function useSensorConfig() {
     const v = useContext(Ctx);
     if (!v) throw new Error('useSensorConfig must be used inside SensorConfigProvider');

--- a/src/pages/common/Sidebar/index.jsx
+++ b/src/pages/common/Sidebar/index.jsx
@@ -1,11 +1,9 @@
 import React, { useState, useEffect } from "react";
 import { NavLink } from "react-router-dom";
 import styles from "./Sidebar.module.css";
-import { useFilters, ALL } from "../../../context/FiltersContext.jsx";
 
 export default function Sidebar() {
     const [collapsed, setCollapsed] = useState(() => window.innerWidth < 768);
-    const { device, layer, system, topic, setDevice, setLayer, setSystem, setTopic, lists } = useFilters();
 
     useEffect(() => {
         const handleResize = () => {
@@ -19,39 +17,6 @@ export default function Sidebar() {
 
     const linkClass = ({ isActive }) =>
         `${styles.menuItem} ${isActive ? styles.active : ""}`;
-
-    const CheckboxGroup = ({ title, list, value, onChange }) => (
-        <div className={styles.filterGroup}>
-            {!collapsed && <div className={styles.filterLabel}>{title}</div>}
-
-            {!collapsed && (
-                <div className={styles.dropdown}>
-                    <label className={`${styles.option} ${value === ALL ? styles.selected : ""}`}>
-                        <input
-                            type="checkbox"
-                            checked={value === ALL}
-                            onChange={() => onChange(ALL)}
-                        />
-                        All
-                    </label>
-
-                    {list.map((item) => (
-                        <label
-                            key={item}
-                            className={`${styles.option} ${value === item ? styles.selected : ""}`}
-                        >
-                            <input
-                                type="checkbox"
-                                checked={value === item}
-                                onChange={() => onChange(value === item ? ALL : item)}
-                            />
-                            {item}
-                        </label>
-                    ))}
-                </div>
-            )}
-        </div>
-    );
 
     return (
         <aside className={`${styles.sidebar} ${collapsed ? styles.collapsed : ""}`}>
@@ -89,17 +54,6 @@ export default function Sidebar() {
                 </NavLink>
             </nav>
 
-            <div className={styles.divider}/>
-
-            {/* Application filters */}
-            <section className={styles.filters}>
-                {!collapsed && <div className={styles.filtersTitle}>Application filters</div>}
-
-                <CheckboxGroup title="Topic" list={lists.topics} value={topic} onChange={setTopic} />
-                <CheckboxGroup title="Composite ID" list={lists.devices} value={device} onChange={setDevice} />
-                <CheckboxGroup title="Layer" list={lists.layers} value={layer} onChange={setLayer} />
-                <CheckboxGroup title="System" list={lists.systems} value={system} onChange={setSystem} />
-            </section>
         </aside>
     );
 }

--- a/tests/mocks/sensorConfigApi.js
+++ b/tests/mocks/sensorConfigApi.js
@@ -46,7 +46,7 @@ export function mockSensorConfigApi() {
 
       if (method === 'PUT') {
         if (!db[key]) return makeRes(false, 404, 'Not found');
-        const { sensorType, ...rest } = JSON.parse(opts.body || '{}');
+        const { sensorType: _sensorType, ...rest } = JSON.parse(opts.body || '{}');
         db[key] = { sensorType: key, ...rest };
         return makeRes(true, 200, withIdealRange(db[key]));
       }


### PR DESCRIPTION
## Summary
- simplify sidebar by removing application filters and filter context usage
- adjust sensor config mock and context lint directives for clean lint run

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bcafd56af083289d6f79bc089a76f9