### PR TITLE
Simplify SensorDashboard filter logic

### DIFF
--- a/src/pages/Live/components/SensorDashboard/index.jsx
+++ b/src/pages/Live/components/SensorDashboard/index.jsx
@@ -1,87 +1,31 @@
 // SensorDashboard.jsx
-import React, {useEffect, useMemo, useState} from "react";
+import React, {useEffect, useState} from "react";
 import Header from "../../../common/Header";
 import { useLiveDevices } from "../../../common/useLiveDevices.js";
 import styles from "./SensorDashboard.module.css";
 import Live from "../Live";
 import {SENSOR_TOPIC, topics} from "../../../common/dashboard.constants.js";
 
-const ALL = "ALL";
-
 function SensorDashboard({ view, title = '' }) {
-    const [activeSystem, setActiveSystem] = useState("S01");
+    const activeSystem = "S01";
     const {deviceData, sensorData, availableCompositeIds, mergedDevices} = useLiveDevices(topics, activeSystem);
 
     const [selectedDevice, setSelectedDevice] = useState("");
-
-    const devFilter = ALL;
-    const layerFilter = ALL;
-    const sysFilter = ALL;
-    const topicFilter = ALL;
 
     // Topics for the currently active system across all topic streams
     const activeSystemTopics = deviceData[activeSystem] || {};
     const sensorTopicDevices = activeSystemTopics[SENSOR_TOPIC] || {};
 
-    // ──────────────────────────────
-    // 1) Build metadata: compositeId -> { system, layer, baseId, topics: [] }
-    const deviceMeta = useMemo(() => {
-        const map = {};
-        for (const [sysId, topicsObj] of Object.entries(deviceData || {})) {
-            for (const [topicKey, devs] of Object.entries(topicsObj || {})) {
-                for (const [compositeId, payload] of Object.entries(devs || {})) {
-                    const baseId = payload?.deviceId;
-                    const layer = payload?.layer?.layer || payload?.layer || null;
-                    if (!map[compositeId]) {
-                        map[compositeId] = {system: sysId, layer, baseId, topics: new Set([topicKey])};
-                    } else {
-                        map[compositeId].topics.add(topicKey);
-                    }
-                }
-            }
-        }
-        return Object.fromEntries(
-            Object.entries(map).map(([compositeId, m]) => [compositeId, {
-                system: m.system,
-                layer: m.layer,
-                baseId: m.baseId,
-                topics: Array.from(m.topics)
-            }])
-        );
-    }, [deviceData]);
+    // Show all available device IDs and topics
+    const filteredCompositeIds = availableCompositeIds;
+    const filteredSystemTopics = activeSystemTopics;
 
-    // 2) Filter available device IDs based on all active filters
-    const filteredCompositeIds = useMemo(() => {
-        return availableCompositeIds.filter((compositeId) => {
-            const meta = deviceMeta[compositeId] || {};
-            const okDev = devFilter === ALL || compositeId === devFilter;
-            const okLay = layerFilter === ALL || meta.layer === layerFilter;
-            const okSys = sysFilter === ALL || meta.system === sysFilter;
-            const okTopic = topicFilter === ALL || (meta.topics || []).includes(topicFilter);
-            return okDev && okLay && okSys && okTopic;
-        });
-    }, [availableCompositeIds, deviceMeta, devFilter, layerFilter, sysFilter, topicFilter]);
-
-    // 3) Filter topics for live tables based on filtered devices
-    const filteredSystemTopics = useMemo(() => {
-        const out = {};
-        for (const [topic, devs] of Object.entries(activeSystemTopics || {})) {
-            if (topicFilter !== ALL && topic !== topicFilter) continue;
-            out[topic] = Object.fromEntries(
-                Object.entries(devs || {}).filter(([compositeId]) =>
-                    filteredCompositeIds.includes(compositeId)
-                )
-            );
-        }
-        return out;
-    }, [activeSystemTopics, filteredCompositeIds, topicFilter]);
-
-    // 4) Ensure selectedDevice remains valid after filters change
+    // Ensure selectedDevice remains valid after device list changes
     useEffect(() => {
-        if (filteredCompositeIds.length && !filteredCompositeIds.includes(selectedDevice)) {
-            setSelectedDevice(filteredCompositeIds[0]);
+        if (availableCompositeIds.length && !availableCompositeIds.includes(selectedDevice)) {
+            setSelectedDevice(availableCompositeIds[0]);
         }
-    }, [filteredCompositeIds, selectedDevice]);
+    }, [availableCompositeIds, selectedDevice]);
 
     return (
         <div className={styles.dashboard}>


### PR DESCRIPTION
## Summary
- remove unused filter hooks from `SensorDashboard`
- show all available devices and topics by default

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bcb34007e48328a6e8a5e5ebd5a8c5