### PR TITLE
Aggregate live device data across systems

### DIFF
--- a/src/pages/common/useLiveDevices.js
+++ b/src/pages/common/useLiveDevices.js
@@ -17,7 +17,7 @@ function mergeControllers(a = [], b = []) {
     return Array.from(map.values());
 }
 
-export function useLiveDevices(topics, activeSystem) {
+export function useLiveDevices(topics) {
     const [deviceData, setDeviceData] = useState({});
     const [sensorData, setSensorData] = useState({});
 
@@ -63,31 +63,33 @@ export function useLiveDevices(topics, activeSystem) {
     useStomp(topics, handleStompMessage);
 
     const availableCompositeIds = useMemo(() => {
-        const sysData = deviceData[activeSystem] || {};
         const ids = new Set();
-        for (const topicDevices of Object.values(sysData)) {
-            for (const cid of Object.keys(topicDevices)) {
-                ids.add(cid);
+        for (const sysData of Object.values(deviceData)) {
+            for (const topicDevices of Object.values(sysData)) {
+                for (const cid of Object.keys(topicDevices)) {
+                    ids.add(cid);
+                }
             }
         }
         return Array.from(ids);
-    }, [deviceData, activeSystem]);
+    }, [deviceData]);
 
     const mergedDevices = useMemo(() => {
-        const sysData = deviceData[activeSystem] || {};
         const combined = {};
-        for (const topicKey of Object.keys(sysData)) {
-            for (const [cid, data] of Object.entries(sysData[topicKey])) {
-                const existing = combined[cid] || {};
-                combined[cid] = {
-                    ...existing,
-                    ...data,
-                    controllers: mergeControllers(existing.controllers, data.controllers)
-                };
+        for (const sysData of Object.values(deviceData)) {
+            for (const topicKey of Object.keys(sysData)) {
+                for (const [cid, data] of Object.entries(sysData[topicKey])) {
+                    const existing = combined[cid] || {};
+                    combined[cid] = {
+                        ...existing,
+                        ...data,
+                        controllers: mergeControllers(existing.controllers, data.controllers)
+                    };
+                }
             }
         }
         return combined;
-    }, [deviceData, activeSystem]);
+    }, [deviceData]);
 
     return {deviceData, sensorData, availableCompositeIds, mergedDevices};
 }


### PR DESCRIPTION
## Summary
- Remove hard-coded system filter and aggregate topics across systems in SensorDashboard
- Refactor useLiveDevices hook to iterate through all systems and expose merged IDs/devices globally
- Update hook usage and tests to cover multi-system scenarios

## Testing
- `CI=true npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68bcb766c0988328975653ce70f55996