### PR TITLE
feat: add header to all pages

### DIFF
--- a/src/pages/Dashboard/components/DashboardV2.jsx
+++ b/src/pages/Dashboard/components/DashboardV2.jsx
@@ -7,6 +7,7 @@ import styles from "./DashboardV2.module.css";
 import { useSensorConfig } from "../../../context/SensorConfigContext.jsx";
 import useWaterCompositeCards from "./useWaterCompositeCards.js";
 import { useStomp } from "../../../hooks/useStomp";
+import Header from "../../common/Header";
 
 // utils
 import {
@@ -209,6 +210,7 @@ export default function DashboardV2() {
 
     return (
         <div className={styles.page}>
+            <Header title="Dashboard" />
             {(!systems.length || !active) ? (
                 <div>Waiting for data…</div>
                 ) : (

--- a/src/pages/Documentation/index.jsx
+++ b/src/pages/Documentation/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useSensorConfig } from '../../context/SensorConfigContext.jsx';
+import Header from "../common/Header";
 
 function Documentation() {
     const { configs, error, loading } = useSensorConfig();
@@ -18,10 +19,11 @@ function Documentation() {
 
     return (
         <div>
-            <h1>Ideal Ranges</h1>
+            <Header title="Documentation" />
+            <h2>Ideal Ranges</h2>
             {Object.entries(configs).map(([key, value]) => (
                 <section key={key}>
-                    <h2>{key}</h2>
+                    <h3>{key}</h3>
                     <p>{value.description}</p>
                     {value.idealRange && (
                         <p>

--- a/src/pages/Note/index.jsx
+++ b/src/pages/Note/index.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import Header from "../common/Header";
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? 'http://localhost:8080';
 
@@ -42,34 +43,36 @@ function Note() {
     };
 
     return (
-        <div style={{ padding: '1rem' }}>
-            <h2>Daily Notes</h2>
-            <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', maxWidth: '400px' }}>
-                <input
-                    type="text"
-                    placeholder="Title"
-                    value={title}
-                    onChange={e => setTitle(e.target.value)}
-                    required
-                />
-                <textarea
-                    placeholder="Write your note..."
-                    value={content}
-                    onChange={e => setContent(e.target.value)}
-                    rows={4}
-                    required
-                />
-                <button type="submit">Save</button>
-            </form>
+        <div>
+            <Header title="Daily Notes" />
+            <div style={{ padding: '1rem' }}>
+                <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', maxWidth: '400px' }}>
+                    <input
+                        type="text"
+                        placeholder="Title"
+                        value={title}
+                        onChange={e => setTitle(e.target.value)}
+                        required
+                    />
+                    <textarea
+                        placeholder="Write your note..."
+                        value={content}
+                        onChange={e => setContent(e.target.value)}
+                        rows={4}
+                        required
+                    />
+                    <button type="submit">Save</button>
+                </form>
 
-            <div style={{ marginTop: '1rem' }}>
-                {notes.map((note, idx) => (
-                    <div key={note.id ?? idx} style={{ border: '1px solid #ccc', padding: '0.5rem', marginBottom: '0.5rem' }}>
-                        <strong>{note.title}</strong>
-                        <p>{note.content}</p>
-                        <small>{new Date(note.date).toLocaleString()}</small>
-                    </div>
-                ))}
+                <div style={{ marginTop: '1rem' }}>
+                    {notes.map((note, idx) => (
+                        <div key={note.id ?? idx} style={{ border: '1px solid #ccc', padding: '0.5rem', marginBottom: '0.5rem' }}>
+                            <strong>{note.title}</strong>
+                            <p>{note.content}</p>
+                            <small>{new Date(note.date).toLocaleString()}</small>
+                        </div>
+                    ))}
+                </div>
             </div>
         </div>
     );

--- a/src/pages/Reports/index.jsx
+++ b/src/pages/Reports/index.jsx
@@ -2,6 +2,7 @@ import React, {useEffect, useMemo, useRef, useState} from "react";
 import ReportCharts from "./components/ReportCharts";
 import ReportFiltersCompare from "./components/ReportFiltersCompare";
 import {transformAggregatedData} from "../../utils.js";
+import Header from "../common/Header";
 
 // helpers
 const toCID = (d) => `${d.systemId}-${d.layerId}-${d.deviceId}`;
@@ -226,7 +227,9 @@ export default function Reports() {
     const selectedDeviceLabel = selectedCIDs.length === 1 ? selectedCIDs[0] : "";
 
     return (
-        <div style={{padding: 16}}>
+        <div>
+            <Header title="Reports" />
+            <div style={{padding: 16}}>
             <ReportFiltersCompare
                 fromDate={fromDate}
                 toDate={toDate}
@@ -289,6 +292,7 @@ export default function Reports() {
                     }}
                     xDomain={xDomain}
                 />
+            </div>
             </div>
         </div>
     );

--- a/src/pages/SensorConfig/index.jsx
+++ b/src/pages/SensorConfig/index.jsx
@@ -2,6 +2,7 @@
 import React, { useMemo, useState } from "react";
 import { useSensorConfig } from "../../context/SensorConfigContext.jsx";
 import styles from "./SensorConfigPage.module.css";
+import Header from "../common/Header";
 
 export default function SensorConfigPage() {
     const { configs, error, createConfig, updateConfig, deleteConfig } = useSensorConfig();
@@ -170,7 +171,7 @@ export default function SensorConfigPage() {
 
     return (
         <div className={styles.page}>
-            <h1 className={styles.title}>Sensor Config</h1>
+            <Header title="Sensor Config" />
 
             {error && <div role="alert" className={styles.alert}>{error}</div>}
             {message && <div role="status" className={styles.status}>{message}</div>}

--- a/src/pages/UserInfo/index.jsx
+++ b/src/pages/UserInfo/index.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import Header from "../common/Header";
 
 function UserInfo() {
     return (
         <div>
-            User Info
+            <Header title="User Info" />
+            <div>User Info</div>
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- add shared header with clock and title to Dashboard, Reports, Documentation, Note, Sensor Config, and User Info pages for consistency

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bcbfed12608328aa43bf11faa08f1d