### PR TITLE
Fix reports sensor All selection

### DIFF
--- a/src/pages/Reports/components/ReportFiltersCompare.jsx
+++ b/src/pages/Reports/components/ReportFiltersCompare.jsx
@@ -43,10 +43,11 @@ function Checklist({options = [], values = [], onToggle}) {
 }
 
 function Group({title, name, options = [], values = [], onAll, onNone, onToggle}) {
+    const handleAll = () => onAll && onAll(options);
     return (
         <div className={styles.group}>
             <div className={styles.groupTitle}>{title}</div>
-            <AllNone name={name} onAll={onAll} onNone={onNone}/>
+            <AllNone name={name} onAll={handleAll} onNone={onNone}/>
             <Checklist options={options} values={values} onToggle={onToggle}/>
         </div>
     );

--- a/tests/ReportFiltersCompareSensorAll.test.jsx
+++ b/tests/ReportFiltersCompareSensorAll.test.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ReportFiltersCompare from '../src/pages/Reports/components/ReportFiltersCompare.jsx';
+
+test('All selects all sensors and notifies parent', () => {
+  const onAllWater = vi.fn();
+  render(
+    <ReportFiltersCompare
+      fromDate=""
+      toDate=""
+      onFromDateChange={() => {}}
+      onToDateChange={() => {}}
+      onApply={() => {}}
+      onReset={() => {}}
+      onAddCompare={() => {}}
+      onExportCsv={() => {}}
+      rangeLabel=""
+      water={{ values: [] }}
+      onAllWater={onAllWater}
+      onNoneWater={() => {}}
+    />
+  );
+
+  fireEvent.click(screen.getByLabelText('All', { selector: 'input[name="water"]' }));
+  const labels = onAllWater.mock.calls[0][0].map((o) => (typeof o === 'string' ? o : o.label));
+  expect(labels).toEqual(['dissolvedTemp', 'dissolvedEC', 'dissolvedTDS', 'dissolvedOxygen']);
+});


### PR DESCRIPTION
## Summary
- Fix "All" button in sensor type filters to actually select all available sensors
- Add regression test for selecting all sensor types

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bcc158138c8328a364b84651b28f3b