### PR TITLE
Handle notes endpoint errors with fallback UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ VITE_API_BASE=
 Additionally, set `VITE_WS_URL` to the WebSocket endpoint that provides the live
 STOMP feed. If not defined, it defaults to `wss://api.hydroleaf.se/ws`.
 Set `VITE_API_BASE` to the base URL for REST API requests. When omitted,
-requests default to `https://api.hydroleaf.se`.
+requests default to `https://api.hydroleaf.se`. For pages that communicate with
+the backend (such as the Notes page), this should point to a running API
+instance that exposes the expected endpoints.
 
 These variables are used to establish the MQTT connection.
 Make sure the file is named `.env` and each variable starts with the `VITE_` prefix so that Vite exposes them to the frontend.

--- a/src/pages/Note/index.jsx
+++ b/src/pages/Note/index.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import Header from "../common/Header";
 
-const API_BASE = import.meta.env.VITE_API_BASE ?? 'http://localhost:8080';
+const API_BASE = import.meta.env.VITE_API_BASE || 'https://api.hydroleaf.se';
 
 function Note() {
     const [title, setTitle] = useState('');

--- a/src/pages/Note/index.jsx
+++ b/src/pages/Note/index.jsx
@@ -7,17 +7,19 @@ function Note() {
     const [title, setTitle] = useState('');
     const [content, setContent] = useState('');
     const [notes, setNotes] = useState([]);
+    const [error, setError] = useState('');
 
     useEffect(() => {
         (async () => {
             try {
                 const res = await fetch(`${API_BASE}/api/notes`);
-                if (res.ok) {
-                    const data = await res.json();
-                    setNotes(Array.isArray(data) ? data : []);
-                }
+                if (!res.ok) throw new Error(`Request failed with status ${res.status}`);
+                const data = await res.json();
+                setNotes(Array.isArray(data) ? data : []);
+                setError('');
             } catch (e) {
                 console.error(e);
+                setError('Failed to load notes. Please try again later.');
             }
         })();
     }, []);
@@ -31,14 +33,15 @@ function Note() {
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(newNote)
             });
-            if (res.ok) {
-                const saved = await res.json().catch(() => newNote);
-                setNotes(prev => [saved, ...prev]);
-                setTitle('');
-                setContent('');
-            }
+            if (!res.ok) throw new Error(`Request failed with status ${res.status}`);
+            const saved = await res.json().catch(() => newNote);
+            setNotes(prev => [saved, ...prev]);
+            setTitle('');
+            setContent('');
+            setError('');
         } catch (err) {
             console.error(err);
+            setError('Failed to save note. Please try again.');
         }
     };
 
@@ -46,6 +49,7 @@ function Note() {
         <div>
             <Header title="Daily Notes" />
             <div style={{ padding: '1rem' }}>
+                {error && <div style={{ color: 'red', marginBottom: '0.5rem' }}>{error}</div>}
                 <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', maxWidth: '400px' }}>
                     <input
                         type="text"


### PR DESCRIPTION
## Summary
- detect API failures when fetching or saving notes
- show user-friendly error messages on the Notes page
- document VITE_API_BASE requirement for backend API

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68bd81c2a2e8832890a704f5719e16e0