### PR TITLE
feat: enable viewing multiple cameras

### DIFF
--- a/src/pages/Cameras/Cameras.module.css
+++ b/src/pages/Cameras/Cameras.module.css
@@ -1,0 +1,23 @@
+.grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 1rem;
+}
+
+.camera {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.cameraVideo {
+    width: 100%;
+    height: auto;
+    background: black;
+}
+
+.label {
+    margin-top: 0.25rem;
+    font-size: 0.9em;
+    text-align: center;
+}

--- a/src/pages/Cameras/index.jsx
+++ b/src/pages/Cameras/index.jsx
@@ -1,9 +1,64 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import styles from './Cameras.module.css';
 
 function Cameras() {
+    const [devices, setDevices] = useState([]);
+    const videoRefs = useRef([]);
+    const streams = useRef([]);
+
+    useEffect(() => {
+        async function init() {
+            try {
+                await navigator.mediaDevices.getUserMedia({ video: true, audio: false });
+                const deviceInfos = await navigator.mediaDevices.enumerateDevices();
+                const cams = deviceInfos.filter(d => d.kind === 'videoinput');
+                setDevices(cams);
+            } catch (err) {
+                console.error('Could not access cameras', err);
+            }
+        }
+        init();
+
+        const currentStreams = streams.current;
+        return () => {
+            currentStreams.forEach(stream => {
+                stream.getTracks().forEach(t => t.stop());
+            });
+        };
+    }, []);
+
+    useEffect(() => {
+        devices.forEach((device, idx) => {
+            if (!videoRefs.current[idx] || streams.current[idx]) return;
+            navigator.mediaDevices
+                .getUserMedia({ video: { deviceId: { exact: device.deviceId } }, audio: false })
+                .then(stream => {
+                    streams.current[idx] = stream;
+                    if (videoRefs.current[idx]) {
+                        videoRefs.current[idx].srcObject = stream;
+                    }
+                })
+                .catch(err => {
+                    console.error('Could not start stream', device.label, err);
+                });
+        });
+    }, [devices]);
+
     return (
-        <div>
-            Cameras page
+        <div className={styles.grid}>
+            {devices.map((device, idx) => (
+                <div key={device.deviceId} className={styles.camera}>
+                    <video
+                        ref={el => (videoRefs.current[idx] = el)}
+                        className={styles.cameraVideo}
+                        autoPlay
+                        playsInline
+                        muted
+                    />
+                    <div className={styles.label}>{device.label || `Camera ${idx + 1}`}</div>
+                </div>
+            ))}
+            {devices.length === 0 && <p>No cameras found.</p>}
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- add Cameras page grid to stream multiple video inputs simultaneously
- style camera grid and labels

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1d2a5744c8328ba66b674ac72d2fa