### PR TITLE
Improve camera stream handling and feedback

### DIFF
--- a/src/pages/Cameras/Cameras.module.css
+++ b/src/pages/Cameras/Cameras.module.css
@@ -5,19 +5,70 @@
   align-items: center;
   padding: 1rem;
 }
-.title { margin-bottom: 1rem; }
+
+.title {
+  margin-bottom: 1rem;
+}
+
 .video {
   width: 100%;
   max-width: 720px;
+  aspect-ratio: 16 / 9;
   background: #000;
   border-radius: 8px;
+  display: block;
+  object-fit: cover;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.18);
 }
-.controls {
+
+.statusRow {
   display: flex;
-  gap: 0.5rem;
+  align-items: center;
+  gap: 0.75rem;
   margin-top: 1rem;
   width: 100%;
   max-width: 720px;
 }
-.input { flex: 1; padding: 0.5rem; }
-.button { padding: 0.5rem 0.75rem; cursor: pointer; }
+
+.statusMessage {
+  flex: 1;
+  margin: 0;
+  font-size: 0.95rem;
+  color: #475569;
+}
+
+.statusLoading {
+  color: #475569;
+}
+
+.statusPlaying {
+  color: #15803d;
+}
+
+.statusInteraction,
+.statusError {
+  color: #b91c1c;
+}
+
+.button {
+  padding: 0.5rem 0.9rem;
+  background: #2563eb;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 600;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.button:hover:not(:disabled) {
+  background: #1d4ed8;
+  transform: translateY(-1px);
+}
+
+.button:disabled {
+  background: #94a3b8;
+  cursor: not-allowed;
+  transform: none;
+}

--- a/src/pages/Cameras/index.jsx
+++ b/src/pages/Cameras/index.jsx
@@ -1,5 +1,5 @@
 // pages/Cameras/index.jsx
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import Hls from "hls.js";
 import styles from "./Cameras.module.css";
 
@@ -8,99 +8,225 @@ const SRC =
     (import.meta?.env && import.meta.env.VITE_TAPO_HLS) ||
     "https://cam.hydroleaf.se/tapo/index.m3u8";
 
+const STATUS_MESSAGES = {
+    loading: "Loading stream…",
+    playing: "Live stream",
+    interaction: "Autoplay was blocked. Press play on the player controls.",
+    error: "Unable to load the camera stream.",
+};
+
 export default function Cameras() {
-  const videoRef = useRef(null);
-  const hlsRef = useRef(null); // keep instance for cleanup
+    const videoRef = useRef(null);
+    const hlsRef = useRef(null); // keep instance for cleanup
+    const [status, setStatus] = useState({ state: "loading", message: STATUS_MESSAGES.loading });
+    const [reloadKey, setReloadKey] = useState(0);
 
-  useEffect(() => {
-    const video = videoRef.current;
-    if (!video) return;
+    useEffect(() => {
+        const video = videoRef.current;
+        if (!video) return undefined;
 
-    // clean any previous instance
-    if (hlsRef.current) {
-      try { hlsRef.current.destroy(); } catch {}
-      hlsRef.current = null;
-    }
+        const setState = (state, message) => {
+            setStatus({ state, message: message || STATUS_MESSAGES[state] || "" });
+        };
 
-    // set attributes for autoplay policies
-    video.crossOrigin = "anonymous";
-    video.autoplay = true;
-    video.muted = true;       // required for autoplay
-    video.playsInline = true; // iOS inline
-    video.preload = "auto";
+        const cleanupHls = () => {
+            if (!hlsRef.current) return;
+            try {
+                hlsRef.current.destroy();
+            } catch (err) {
+                console.warn("Failed to destroy hls instance", err);
+            }
+            hlsRef.current = null;
+        };
 
-    // Native HLS (Safari/iOS)
-    if (video.canPlayType("application/vnd.apple.mpegurl")) {
-      video.src = SRC;
-      video.load();
-      const onLoaded = () => video.play().catch(() => {});
-      video.addEventListener("loadedmetadata", onLoaded, { once: true });
+        cleanupHls();
 
-      return () => {
-        video.removeEventListener("loadedmetadata", onLoaded);
-      };
-    }
+        video.pause();
+        video.removeAttribute("src");
+        video.load();
 
-    // hls.js for other browsers
-    if (Hls.isSupported()) {
-      const hls = new Hls({
-        enableWorker: true,
-        lowLatencyMode: false,        // classic HLS; stable with MediaMTX mpegts
-        liveSyncDuration: 2,
-        liveMaxLatencyDuration: 6,
-        maxLiveSyncPlaybackRate: 1.2,
-      });
-      hlsRef.current = hls;
+        setState("loading");
 
-      hls.attachMedia(video);
-      hls.on(Hls.Events.MEDIA_ATTACHED, () => {
-        hls.loadSource(SRC);
-      });
+        video.crossOrigin = "anonymous";
+        video.autoplay = true;
+        video.muted = true; // required for autoplay
+        video.playsInline = true; // iOS inline
+        video.preload = "auto";
 
-      // basic error recovery
-      hls.on(Hls.Events.ERROR, (_evt, data) => {
-        console.error("HLS error:", data);
-        if (!data?.fatal) return;
-        switch (data.type) {
-          case Hls.ErrorTypes.NETWORK_ERROR:
-            try { hls.startLoad(); } catch {}
-            break;
-          case Hls.ErrorTypes.MEDIA_ERROR:
-            try { hls.recoverMediaError(); } catch {}
-            break;
-          default:
-            try { hls.destroy(); } catch {}
-            break;
+        const handlePlaybackStart = () => {
+            try {
+                const playPromise = video.play();
+                if (playPromise && typeof playPromise.then === "function") {
+                    playPromise
+                        .then(() => setState("playing"))
+                        .catch(() => setState("interaction"));
+                } else {
+                    setState("playing");
+                }
+            } catch (err) {
+                console.error("Playback start error", err);
+                setState("interaction");
+            }
+        };
+
+        const onVideoPlaying = () => setState("playing");
+        const onVideoError = () => setState("error");
+
+        video.addEventListener("playing", onVideoPlaying);
+        video.addEventListener("error", onVideoError);
+
+        // Native HLS (Safari/iOS)
+        if (video.canPlayType("application/vnd.apple.mpegurl")) {
+            video.src = SRC;
+            video.load();
+            const onLoaded = () => handlePlaybackStart();
+            video.addEventListener("loadedmetadata", onLoaded, { once: true });
+
+            return () => {
+                video.removeEventListener("loadedmetadata", onLoaded);
+                video.removeEventListener("playing", onVideoPlaying);
+                video.removeEventListener("error", onVideoError);
+                video.pause();
+                video.removeAttribute("src");
+                video.load();
+            };
         }
-      });
 
-      const onLoaded = () => video.play().catch(() => {});
-      video.addEventListener("loadedmetadata", onLoaded, { once: true });
+        // hls.js for other browsers
+        if (Hls.isSupported()) {
+            const hls = new Hls({
+                enableWorker: true,
+                lowLatencyMode: false, // classic HLS; stable with MediaMTX mpegts
+                liveSyncDuration: 2,
+                liveMaxLatencyDuration: 6,
+                maxLiveSyncPlaybackRate: 1.2,
+                backBufferLength: 30,
+            });
+            hlsRef.current = hls;
 
-      return () => {
-        video.removeEventListener("loadedmetadata", onLoaded);
-        try { hls.destroy(); } catch {}
-        hlsRef.current = null;
-      };
-    }
+            const onManifestParsed = () => handlePlaybackStart();
+            const onHlsError = (_evt, data) => {
+                console.error("HLS error:", data);
+                if (!data) return;
+                if (!data.fatal) {
+                    if (data.type === Hls.ErrorTypes.NETWORK_ERROR) {
+                        setState("loading", "Network hiccup detected. Reconnecting…");
+                    }
+                    return;
+                }
 
-    // ultimate fallback
-    video.src = SRC;
-    video.load();
+                switch (data.type) {
+                    case Hls.ErrorTypes.NETWORK_ERROR:
+                        setState("error", "Network error while fetching the stream.");
+                        try {
+                            hls.startLoad();
+                        } catch (err) {
+                            console.warn("Failed to restart HLS load", err);
+                        }
+                        break;
+                    case Hls.ErrorTypes.MEDIA_ERROR:
+                        setState("error", "Media error encountered. Attempting recovery…");
+                        try {
+                            hls.recoverMediaError();
+                        } catch (err) {
+                            console.warn("Failed to recover media error", err);
+                        }
+                        break;
+                    default:
+                        setState("error");
+                        try {
+                            hls.destroy();
+                        } catch (err) {
+                            console.warn("Failed to destroy hls after fatal error", err);
+                        }
+                        hlsRef.current = null;
+                        break;
+                }
+            };
 
-    // no special cleanup for fallback
-  }, []);
+            hls.attachMedia(video);
+            hls.on(Hls.Events.MEDIA_ATTACHED, () => {
+                hls.loadSource(SRC);
+            });
+            hls.on(Hls.Events.MANIFEST_PARSED, onManifestParsed);
+            hls.on(Hls.Events.ERROR, onHlsError);
 
-  return (
-      <div className={styles.container}>
-        <h2 className={styles.title}>Tapo Camera Stream</h2>
-        <video
-            ref={videoRef}
-            className={styles.video}
-            controls
-            muted
-            playsInline
-        />
-      </div>
-  );
+            return () => {
+                video.removeEventListener("playing", onVideoPlaying);
+                video.removeEventListener("error", onVideoError);
+                try {
+                    hls.off(Hls.Events.MANIFEST_PARSED, onManifestParsed);
+                    hls.off(Hls.Events.ERROR, onHlsError);
+                    hls.destroy();
+                } catch (err) {
+                    console.warn("Failed to dispose hls", err);
+                }
+                hlsRef.current = null;
+                video.pause();
+                video.removeAttribute("src");
+                video.load();
+            };
+        }
+
+        // ultimate fallback
+        video.src = SRC;
+        video.load();
+        const onLoaded = () => handlePlaybackStart();
+        video.addEventListener("loadedmetadata", onLoaded, { once: true });
+
+        return () => {
+            video.removeEventListener("loadedmetadata", onLoaded);
+            video.removeEventListener("playing", onVideoPlaying);
+            video.removeEventListener("error", onVideoError);
+            video.pause();
+            video.removeAttribute("src");
+            video.load();
+        };
+    }, [reloadKey]);
+
+    const handleReload = () => {
+        setReloadKey((key) => key + 1);
+    };
+
+    const statusClass = () => {
+        switch (status.state) {
+            case "playing":
+                return styles.statusPlaying;
+            case "interaction":
+                return styles.statusInteraction;
+            case "error":
+                return styles.statusError;
+            case "loading":
+                return styles.statusLoading;
+            default:
+                return "";
+        }
+    };
+
+    return (
+        <div className={styles.container}>
+            <h2 className={styles.title}>Tapo Camera Stream</h2>
+            <video
+                ref={videoRef}
+                className={styles.video}
+                controls
+                muted
+                playsInline
+                autoPlay
+            />
+            <div className={styles.statusRow}>
+                <p className={`${styles.statusMessage} ${statusClass()}`} aria-live="polite">
+                    {status.message || STATUS_MESSAGES[status.state] || ""}
+                </p>
+                <button
+                    type="button"
+                    className={styles.button}
+                    onClick={handleReload}
+                    disabled={status.state === "loading"}
+                >
+                    Reload
+                </button>
+            </div>
+        </div>
+    );
 }


### PR DESCRIPTION
## Summary
- add status management to the Cameras page to surface loading, playback and error states
- improve HLS lifecycle handling with explicit cleanup, autoplay recovery messaging and a manual reload button
- refresh camera page styling to keep the video visible and align the new status controls

## Testing
- npm run lint
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cbe3d963388328bf41420b8f3a0e0a