### PR TITLE
Improve camera stream error diagnostics

### DIFF
--- a/src/pages/Cameras/errorMessages.js
+++ b/src/pages/Cameras/errorMessages.js
@@ -1,0 +1,35 @@
+// pages/Cameras/errorMessages.js
+
+export const DEFAULT_CAMERA_ERROR_MESSAGE = "Unable to load the camera stream.";
+
+const MEDIA_ERROR_MESSAGES = {
+    1: "Playback was aborted before it could start.",
+    2: "A network issue interrupted the camera stream.",
+    3: "The browser could not decode the camera stream.",
+    4: "The browser could not access the stream URL or format.",
+};
+
+export const MIXED_CONTENT_MESSAGE =
+    "The dashboard is served over HTTPS but the camera stream uses HTTP. Browsers block this mixed content. Update the stream to HTTPS or open the dashboard over HTTP.";
+
+export function getCameraErrorMessage({
+    errorCode,
+    errorMessage,
+    streamUrl,
+    pageProtocol,
+} = {}) {
+    if (pageProtocol === "https:" && typeof streamUrl === "string" && streamUrl.startsWith("http:")) {
+        return MIXED_CONTENT_MESSAGE;
+    }
+
+    if (errorMessage) {
+        return errorMessage;
+    }
+
+    if (errorCode && MEDIA_ERROR_MESSAGES[errorCode]) {
+        return MEDIA_ERROR_MESSAGES[errorCode];
+    }
+
+    return DEFAULT_CAMERA_ERROR_MESSAGE;
+}
+

--- a/src/pages/Cameras/index.jsx
+++ b/src/pages/Cameras/index.jsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import Hls from "hls.js";
 import styles from "./Cameras.module.css";
+import { getCameraErrorMessage, DEFAULT_CAMERA_ERROR_MESSAGE } from "./errorMessages";
 
 // pick URL from env or fallback
 const SRC =
@@ -12,7 +13,7 @@ const STATUS_MESSAGES = {
     loading: "Loading stream…",
     playing: "Live stream",
     interaction: "Autoplay was blocked. Press play on the player controls.",
-    error: "Unable to load the camera stream.",
+    error: DEFAULT_CAMERA_ERROR_MESSAGE,
 };
 
 export default function Cameras() {
@@ -70,7 +71,15 @@ export default function Cameras() {
         };
 
         const onVideoPlaying = () => setState("playing");
-        const onVideoError = () => setState("error");
+        const onVideoError = () => {
+            const errorMessage = getCameraErrorMessage({
+                errorCode: video?.error?.code,
+                errorMessage: video?.error?.message,
+                streamUrl: SRC,
+                pageProtocol: typeof window !== "undefined" ? window.location?.protocol : undefined,
+            });
+            setState("error", errorMessage);
+        };
 
         video.addEventListener("playing", onVideoPlaying);
         video.addEventListener("error", onVideoError);

--- a/tests/cameraErrorMessages.test.js
+++ b/tests/cameraErrorMessages.test.js
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+    getCameraErrorMessage,
+    DEFAULT_CAMERA_ERROR_MESSAGE,
+    MIXED_CONTENT_MESSAGE,
+} from "../src/pages/Cameras/errorMessages";
+
+describe("getCameraErrorMessage", () => {
+    it("returns the mixed content message when HTTPS page requests an HTTP stream", () => {
+        const message = getCameraErrorMessage({
+            streamUrl: "http://camera.local/stream.m3u8",
+            pageProtocol: "https:",
+        });
+
+        expect(message).toBe(MIXED_CONTENT_MESSAGE);
+    });
+
+    it("uses provided error message when available", () => {
+        const message = getCameraErrorMessage({
+            errorMessage: "Custom error",
+            errorCode: 2,
+        });
+
+        expect(message).toBe("Custom error");
+    });
+
+    it("maps media error codes to descriptive text", () => {
+        const message = getCameraErrorMessage({ errorCode: 3 });
+
+        expect(message).toBe("The browser could not decode the camera stream.");
+    });
+
+    it("falls back to default message when it cannot determine the cause", () => {
+        const message = getCameraErrorMessage();
+
+        expect(message).toBe(DEFAULT_CAMERA_ERROR_MESSAGE);
+    });
+});


### PR DESCRIPTION
## Summary
- add a camera error helper that reports mixed-content and browser media issues
- update the Cameras page to surface the helper messages instead of a generic error
- add unit coverage for the new helper logic

## Testing
- npm test -- --run


------
https://chatgpt.com/codex/tasks/task_e_68cbeacc093083288af882be8eae208d