### PR TITLE
Normalize camera stream URL when checking for mixed content

### DIFF
--- a/src/pages/Cameras/errorMessages.js
+++ b/src/pages/Cameras/errorMessages.js
@@ -23,7 +23,10 @@ export function getCameraErrorMessage({
     streamUrl,
     pageProtocol,
 } = {}) {
-    if (pageProtocol === "https:" && typeof streamUrl === "string" && streamUrl.startsWith("http:")) {
+    const normalizedStreamUrl =
+        typeof streamUrl === "string" ? streamUrl.trim().toLowerCase() : undefined;
+
+    if (pageProtocol === "https:" && normalizedStreamUrl && normalizedStreamUrl.startsWith("http:")) {
         return MIXED_CONTENT_MESSAGE;
     }
 

--- a/tests/cameraErrorMessages.test.js
+++ b/tests/cameraErrorMessages.test.js
@@ -15,6 +15,15 @@ describe("getCameraErrorMessage", () => {
         expect(message).toBe(MIXED_CONTENT_MESSAGE);
     });
 
+    it("normalizes the stream URL before checking for mixed content", () => {
+        const message = getCameraErrorMessage({
+            streamUrl: "  HTTP://camera.local/stream.m3u8  ",
+            pageProtocol: "https:",
+        });
+
+        expect(message).toBe(MIXED_CONTENT_MESSAGE);
+    });
+
     it("uses provided error message when available", () => {
         const message = getCameraErrorMessage({
             errorMessage: "Custom error",


### PR DESCRIPTION
## Summary
- normalize camera stream URLs before checking for mixed content so HTTPS dashboards show the correct warning
- add a unit test covering uppercase and padded HTTP URLs

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cbef1cd04c8328b3ec9847e0fb39c9